### PR TITLE
Prevent an extra copy of the serialisation buffer to be made.

### DIFF
--- a/igbinary.c
+++ b/igbinary.c
@@ -156,7 +156,7 @@ struct igbinary_unserialize_data {
 /* }}} */
 /* {{{ Serializing functions prototypes */
 inline static int igbinary_serialize_data_init(struct igbinary_serialize_data *igsd, bool scalar TSRMLS_DC);
-inline static void igbinary_serialize_data_deinit(struct igbinary_serialize_data *igsd TSRMLS_DC);
+inline static void igbinary_serialize_data_deinit(struct igbinary_serialize_data *igsd, int free_buffer TSRMLS_DC);
 
 inline static int igbinary_serialize_header(struct igbinary_serialize_data *igsd TSRMLS_DC);
 
@@ -344,22 +344,26 @@ IGBINARY_API int igbinary_serialize(uint8_t **ret, size_t *ret_len, zval *z TSRM
 
 	if (igbinary_serialize_header(&igsd TSRMLS_CC) != 0) {
 		zend_error(E_WARNING, "igbinary_serialize: cannot write header");
-		igbinary_serialize_data_deinit(&igsd TSRMLS_CC);
+		igbinary_serialize_data_deinit(&igsd, 1 TSRMLS_CC);
 		return 1;
 	}
 
 	if (igbinary_serialize_zval(&igsd, z TSRMLS_CC) != 0) {
-		igbinary_serialize_data_deinit(&igsd TSRMLS_CC);
+		igbinary_serialize_data_deinit(&igsd, 1 TSRMLS_CC);
 		return 1;
 	}
 
 	/* Explicit nul termination */
-	*ret_len = igsd.buffer_size;
-	*ret = (uint8_t *) emalloc(igsd.buffer_size + 1);
-	memcpy(*ret, igsd.buffer, igsd.buffer_size);
-	*(*ret + igsd.buffer_size) = 0;
+	if (igbinary_serialize8(&igsd, 0 TSRMLS_CC) != 0) {
+		igbinary_serialize_data_deinit(&igsd, 1 TSRMLS_CC);
+		return 1;
+	}
 
-	igbinary_serialize_data_deinit(&igsd TSRMLS_CC);
+	/* Set return values */
+	*ret_len = igsd.buffer_size - 1;
+	*ret = igsd.buffer;
+
+	igbinary_serialize_data_deinit(&igsd, 0 TSRMLS_CC);
 
 	return 0;
 }
@@ -445,12 +449,12 @@ PS_SERIALIZER_ENCODE_FUNC(igbinary)
 
 	if (igbinary_serialize_header(&igsd TSRMLS_CC) != 0) {
 		zend_error(E_WARNING, "igbinary_serailize: cannot write header");
-		igbinary_serialize_data_deinit(&igsd TSRMLS_CC);
+		igbinary_serialize_data_deinit(&igsd, 1 TSRMLS_CC);
 		return FAILURE;
 	}
 
 	if (igbinary_serialize_array(&igsd, PS(http_session_vars), false, false TSRMLS_CC) != 0) {
-		igbinary_serialize_data_deinit(&igsd TSRMLS_CC);
+		igbinary_serialize_data_deinit(&igsd, 1 TSRMLS_CC);
 		return FAILURE;
 	}
 
@@ -464,7 +468,7 @@ PS_SERIALIZER_ENCODE_FUNC(igbinary)
 		*newlen = igsd.buffer_size;
 	}
 
-	igbinary_serialize_data_deinit(&igsd TSRMLS_CC);
+	igbinary_serialize_data_deinit(&igsd, 1 TSRMLS_CC);
 
 	return SUCCESS;
 }
@@ -587,8 +591,8 @@ inline static int igbinary_serialize_data_init(struct igbinary_serialize_data *i
 /* }}} */
 /* {{{ igbinary_serialize_data_deinit */
 /** Deinits igbinary_serialize_data. */
-inline static void igbinary_serialize_data_deinit(struct igbinary_serialize_data *igsd TSRMLS_DC) {
-	if (igsd->buffer) {
+inline static void igbinary_serialize_data_deinit(struct igbinary_serialize_data *igsd, int free_buffer TSRMLS_DC) {
+	if (free_buffer && igsd->buffer) {
 		efree(igsd->buffer);
 	}
 


### PR DESCRIPTION
Hi!

This patch prevents the serialization-serialize buffer from being duplicated with an emalloc/memcpy. This pull request has a follow up, that implements methods for setting your own memory manager handling functions.

cheers,
Derick
