### PR TITLE
Issue cflags

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -43,7 +43,7 @@ if test "$PHP_IGBINARY" != "no"; then
 	AC_MSG_CHECKING(compiler type)
 	if test ! -z "`$CC --version | grep -i GCC`"; then
 	  AC_MSG_RESULT(gcc)
-		PHP_IGBINARY_CFLAGS="$CFLAGS -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -Winline -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
+		PHP_IGBINARY_CFLAGS="$CFLAGS -Wall -Wpointer-arith -Wcast-align -Wswitch -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
 	elif test ! -z "`$CC --version | grep -i ICC`"; then
 	  AC_MSG_RESULT(icc)
 		PHP_IGBINARY_CFLAGS="$CFLAGS -no-prec-div -O3 -x0 -unroll2"

--- a/config.m4
+++ b/config.m4
@@ -43,12 +43,13 @@ if test "$PHP_IGBINARY" != "no"; then
 	AC_MSG_CHECKING(compiler type)
 	if test ! -z "`$CC --version | grep -i GCC`"; then
 	  AC_MSG_RESULT(gcc)
-		PHP_IGBINARY_CFLAGS="-Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -Winline -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
+		PHP_IGBINARY_CFLAGS="$CFLAGS -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -Winline -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
 	elif test ! -z "`$CC --version | grep -i ICC`"; then
 	  AC_MSG_RESULT(icc)
-		PHP_IGBINARY_CFLAGS="-no-prec-div -O3 -x0 -unroll2"
+		PHP_IGBINARY_CFLAGS="$CFLAGS -no-prec-div -O3 -x0 -unroll2"
 	else
 	  AC_MSG_RESULT(other)
+		PHP_IGBINARY_CFLAGS="$CFLAGS"
 	fi
 
   PHP_ADD_MAKEFILE_FRAGMENT(Makefile.bench)


### PR DESCRIPTION
First commit allow to honours system CFLAGS, which is mandatory during RPM build, by Guidelines.

FYI, default Fedora CFLAGS are -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -grecord-gcc-switches  -m64 -mtune=generic

Second commit reduce optional flags which raise a lot of warnings during build (especially -Winline)
