### PR TITLE
Added new test for __set beeing called for private variables

### DIFF
--- a/tests/igbinary_048.phpt
+++ b/tests/igbinary_048.phpt
@@ -9,7 +9,7 @@ if(!extension_loaded('igbinary')) {
 <?php
 
 class Bar {
-    public $a = [];
+    public $a = array();
     public $b = array();
     public $c = NULL;
     private $_d = NULL;
@@ -23,7 +23,7 @@ class Foo extends Bar {
 }
 
 $x = new Foo();
-$x->a = [1, 2, 3];
+$x->a = array(1, 2, 3);
 $x->nonexistent = 'aaa';
 
 igbinary_unserialize(igbinary_serialize($x));

--- a/tests/igbinary_048.phpt
+++ b/tests/igbinary_048.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Object test, __set not called for private attr in extended class
+--SKIPIF--
+<?php
+if(!extension_loaded('igbinary')) {
+        echo "skip no igbinary";
+}
+--FILE--
+<?php
+
+class Bar {
+    public $a = [];
+    public $b = array();
+    public $c = NULL;
+    private $_d = NULL;
+    public function __set($name,$value) {
+        echo 'magic function called for ' . $name . ' with ' . var_export($value, true) . PHP_EOL;
+    }
+}
+
+class Foo extends Bar {
+    public $m;
+}
+
+$x = new Foo();
+$x->a = [1, 2, 3];
+$x->nonexistent = 'aaa';
+
+igbinary_unserialize(igbinary_serialize($x));
+--EXPECT--
+magic function called for nonexistent with 'aaa'


### PR DESCRIPTION
This happens in @Sean-Der fork for php7, but I just wanted to contribute it here so it is working for sure in the future version, it passes in playground branches and master.

But other than that, for me, playground1 ends up in:
```
[05-Nov-2015 13:53:38] WARNING: [pool www] child 4162 exited on signal 11 (SIGSEGV) after 5.885494 seconds from start
```
and playground2:
```
E_WARNING: igbinary_unserialize_ref: invalid reference {"code":2,"message":"igbinary_unserialize_ref: invalid reference","file":"/usr/share/nginx/application/vendor/doctrine/cache/lib/Doctrine/Common/Cache/RedisCache.php","line":66}
```
PHP 7.0.0RC6