### PR TITLE
Fixes the php7 APCU serialization/unserialization handler

### DIFF
--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -21,28 +21,16 @@
 #include "ext/standard/info.h"
 #include "ext/standard/php_var.h"
 
-#if PHP_MAJOR_VERSION >= 7
-/* FIXME: still fix sessions and the APC-thingy */
-# undef HAVE_APC_SUPPORT
-# undef HAVE_APCU_SUPPORT
-#endif
-
 #if HAVE_PHP_SESSION
 # include "ext/session/php_session.h"
 #endif /* HAVE_PHP_SESSION */
 
 #include "ext/standard/php_incomplete_class.h"
 
-
+/* Note: there are no checks for APC (project from which APCU was forked) */
 #if defined(HAVE_APCU_SUPPORT)
 # include "ext/apcu/apc_serializer.h"
-#elif defined(HAVE_APC_SUPPORT)
-# if USE_BUNDLED_APC
-#  include "apc_serializer.h"
-# else
-#  include "ext/apc/apc_serializer.h"
-# endif
-#endif /* HAVE_APCU_SUPPORT || HAVE_APC_SUPPORT */
+#endif /* HAVE_APCU_SUPPORT */
 
 #include "php_igbinary.h"
 
@@ -66,7 +54,7 @@
 PS_SERIALIZER_FUNCS(igbinary);
 #endif /* HAVE_PHP_SESSION */
 
-#if defined(HAVE_APC_SUPPORT) || defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
 /** Apc serializer function prototypes */
 static int APC_SERIALIZER_NAME(igbinary) (APC_SERIALIZER_ARGS);
 static int APC_UNSERIALIZER_NAME(igbinary) (APC_UNSERIALIZER_ARGS);
@@ -258,7 +246,6 @@ zend_function_entry igbinary_functions[] = {
 /* }}} */
 
 /* {{{ igbinary dependencies */
-#if ZEND_MODULE_API_NO >= 20050922
 static const zend_module_dep igbinary_module_deps[] = {
 	ZEND_MOD_REQUIRED("standard")
 #ifdef HAVE_PHP_SESSION
@@ -266,12 +253,9 @@ static const zend_module_dep igbinary_module_deps[] = {
 #endif
 #if defined(HAVE_APCU_SUPPORT)
 	ZEND_MOD_OPTIONAL("apcu")
-#elif defined(HAVE_APC_SUPPORT)
-	ZEND_MOD_OPTIONAL("apc")
 #endif
 	ZEND_MOD_END
 };
-#endif
 /* }}} */
 
 /* {{{ igbinary_module_entry */
@@ -328,7 +312,7 @@ PHP_MINIT_FUNCTION(igbinary) {
 		PS_SERIALIZER_DECODE_NAME(igbinary));
 #endif
 
-#if defined(HAVE_APC_SUPPORT) || defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
 	apc_register_serializer("igbinary",
 		APC_SERIALIZER_NAME(igbinary),
 		APC_UNSERIALIZER_NAME(igbinary),
@@ -366,8 +350,6 @@ PHP_MINFO_FUNCTION(igbinary) {
 	php_info_print_table_row(2, "igbinary version", PHP_IGBINARY_VERSION);
 #if defined(HAVE_APCU_SUPPORT)
 	php_info_print_table_row(2, "igbinary APCU serializer ABI", APC_SERIALIZER_ABI);
-#elif defined(HAVE_APC_SUPPORT)
-	php_info_print_table_row(2, "igbinary APC serializer ABI", APC_SERIALIZER_ABI);
 #else
 	php_info_print_table_row(2, "igbinary APC serializer ABI", "no");
 #endif
@@ -669,7 +651,7 @@ PS_SERIALIZER_DECODE_FUNC(igbinary) {
 /* }}} */
 #endif /* HAVE_PHP_SESSION */
 
-#if defined(HAVE_APC_SUPPORT) || defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
 /* {{{ apc_serialize function */
 static int APC_SERIALIZER_NAME(igbinary) ( APC_SERIALIZER_ARGS ) {
 	(void)config;
@@ -686,11 +668,12 @@ static int APC_UNSERIALIZER_NAME(igbinary) ( APC_UNSERIALIZER_ARGS ) {
 	(void)config;
 
 	if (igbinary_unserialize(buf, buf_len, value TSRMLS_CC) == 0) {
-		/* flipped semantics */
+		/* flipped semantics - Succeeded. */
 		return 1;
 	}
-	zval_dtor(*value);
-	(*value)->type = IS_NULL;
+	/* Failed. free return value */
+	zval_ptr_dtor(value);
+	ZVAL_NULL(value); /* and replace the incomplete value with null just in case APCU uses it in the future */
 	return 0;
 }
 /* }}} */

--- a/tests/igbinary_045c.phpt
+++ b/tests/igbinary_045c.phpt
@@ -1,0 +1,94 @@
+--TEST--
+APCu serializer registration - more data types
+--SKIPIF--
+<?php
+if (!extension_loaded('apcu')) {
+	echo "skip APCu not loaded";
+}
+
+$ext = new ReflectionExtension('apcu');
+if (version_compare($ext->getVersion(), '4.0.2', '<')) {
+	echo "skip require APCu version 4.0.2 or above";
+}
+
+if (PHP_MAJOR_VERSION >= 7) {
+	echo "skip bug in APCU itself, https://github.com/krakjoe/apcu/pull/190";
+}
+--INI--
+apc.enable_cli=1
+apc.serializer=igbinary
+--FILE--
+<?php
+echo ini_get('apc.serializer'), "\n";
+
+class Bar {
+	public $foo;
+}
+
+$a = new Bar;
+$a->foo = $a;
+apcu_store('objloop', $a);
+unset($a);
+
+var_dump(apcu_fetch('objloop'));
+
+apcu_store('nullval', null);
+var_dump(apcu_fetch('nullval'));
+
+apcu_store('intval', 777);
+var_dump(apcu_fetch('intval'));
+
+$o = new stdClass();
+$o->prop = 5;
+$a = [$o, $o];
+printf("%s\n", bin2hex(igbinary_serialize($a)));
+apcu_store('simplearrayval', $a);
+var_dump();
+$unserialized = apcu_fetch('simplearrayval');
+var_dump($unserialized);
+var_dump($unserialized[0] === $unserialized[1]) ? 'SAME' : 'DIFFERENT');
+unset($o);
+unset($a);
+unset($unserialized);
+
+$o = new stdClass();
+$o->prop = 6;
+$a = [&$o, &$o];
+apcu_store('refarrayval', $a);
+$unserialized = apcu_fetch('refarrayval');
+var_dump($unserialized);
+var_dump($unserialized[0] === $unserialized[1]) ? 'SAME' : 'DIFFERENT');
+
+--EXPECTF--
+igbinary
+object(Bar)#%d (1) {
+  ["foo"]=>
+  *RECURSION*
+}
+NULL
+int(777)
+array(2) {
+  [0]=>
+  object(stdClass)#%d (2) {
+    ["prop"]=>
+    int(5)
+  }
+  [1]=>
+  object(stdClass)#%d (2) {
+    ["prop"]=>
+    int(5)
+  }
+}
+SAME
+array(2) {
+  [0]=>
+  &object(stdClass)#%d (1) {
+    ["prop"]=>
+    int(6)
+  }
+  &object(stdClass)#%d (1) {
+    ["prop"]=>
+    int(6)
+  }
+}
+SAME


### PR DESCRIPTION
Fixes https://github.com/igbinary/igbinary7/issues/21

There is a bug in the APCU code for custom serializers'
serialization/unserialization methods.
Instead of copying the pointer to an object, it creates clones of
objects. See pull request 190 against krakjoe/apcu.
Waiting until that is fixed to merge these changes.

Note: apcu tests don't run on travis yet.