### PR TITLE
Support PHP_REDIS_IGBINARY (Windows)

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -31,6 +31,12 @@ if (PHP_IGBINARY == "yes") {
     ERROR("Cannot match any known PHP version with '" + dll + "'");
   }
   EXTENSION("igbinary", php_igbinary_src_files);
+  /* needed for PHP_REDIS_IGBINARY, copied from propro config.w32 */
+  var PHP_IGBINARY_HEADERS=glob(configure_module_dirname + "/*.h");
+  for (var i=0; i<PHP_IGBINARY_HEADERS.length; ++i) {
+    var basename = FSO.GetFileName(PHP_IGBINARY_HEADERS[i]);
+    copy_and_subst(configure_module_dirname + "/" + basename, old_conf_dir + "/" + basename, []);
+  }
   configure_module_dirname = old_conf_dir;
   AC_DEFINE('HAVE_IGBINARY', 1, 'Have igbinary support', false);
   ADD_EXTENSION_DEP('igbinary', 'session');


### PR DESCRIPTION
Copy the headers to the root dir of the extension, where the redis extension tries to find them.
With this patch the compile command for php_redis.dll will be:

> "cl.exe" /D PHP_SESSION=1 /I "ext\redis\..\igbinary" /DHAVE_IGBINARY_H=1 et cetera