### PR TITLE
Support PHP_REDIS_IGBINARY (All platforms)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -79,7 +79,7 @@ if test "$PHP_IGBINARY" != "no"; then
   fi
 
   PHP_ADD_MAKEFILE_FRAGMENT(Makefile.bench)
-  PHP_INSTALL_HEADERS([ext/igbinary], [$subdir/igbinary.h])
+  PHP_INSTALL_HEADERS([ext/igbinary], [igbinary.h $subdir/igbinary.h])
   PHP_NEW_EXTENSION(igbinary, $PHP_IGBINARY_SRC_FILES, $ext_shared,, $PHP_IGBINARY_CFLAGS)
   PHP_ADD_EXTENSION_DEP(igbinary, session, true)
   PHP_SUBST(IGBINARY_SHARED_LIBADD)

--- a/config.w32
+++ b/config.w32
@@ -34,4 +34,5 @@ if (PHP_IGBINARY == "yes") {
   configure_module_dirname = old_conf_dir;
   AC_DEFINE('HAVE_IGBINARY', 1, 'Have igbinary support', false);
   ADD_EXTENSION_DEP('igbinary', 'session');
+  PHP_INSTALL_HEADERS('ext/igbinary', 'igbinary.h ' + configure_module_dirname + '\\igbinary.h');
 }

--- a/config.w32
+++ b/config.w32
@@ -23,7 +23,7 @@ if (PHP_IGBINARY == "yes") {
   /* XXX tricky job here, override configure_module_dirname, define the basic extension,
      then set it back*/
   if (null != dll.match(/^php5/)) {
-	subdir = "src\\php5"
+    subdir = "src\\php5"
     php_igbinary_src_files = "igbinary.c hash_si.c"
   } else if (null != dll.match(/^php7/)) {
     subdir = "src\\php7";

--- a/config.w32
+++ b/config.w32
@@ -17,22 +17,24 @@ if (PHP_IGBINARY == "yes") {
   var dll = get_define('PHPDLL');
   var old_conf_dir = configure_module_dirname;
   var php_igbinary_src_files;
+  var subdir;
 
   /* Copied from solr config.w32 */
   /* XXX tricky job here, override configure_module_dirname, define the basic extension,
      then set it back*/
   if (null != dll.match(/^php5/)) {
-    configure_module_dirname = configure_module_dirname + "\\src\\php5";
+	subdir = "src\\php5"
     php_igbinary_src_files = "igbinary.c hash_si.c"
   } else if (null != dll.match(/^php7/)) {
-    configure_module_dirname = configure_module_dirname + "\\src\\php7";
+    subdir = "src\\php7";
     php_igbinary_src_files = "igbinary.c hash_si.c hash_si_ptr.c"
   } else {
     ERROR("Cannot match any known PHP version with '" + dll + "'");
   }
+  configure_module_dirname = configure_module_dirname + "\\" + subdir;
   EXTENSION("igbinary", php_igbinary_src_files);
   configure_module_dirname = old_conf_dir;
   AC_DEFINE('HAVE_IGBINARY', 1, 'Have igbinary support', false);
   ADD_EXTENSION_DEP('igbinary', 'session');
-  PHP_INSTALL_HEADERS('ext/igbinary', 'igbinary.h ' + configure_module_dirname + '\\igbinary.h');
+  PHP_INSTALL_HEADERS('ext/igbinary', 'igbinary.h ' + subdir + '\\igbinary.h');
 }

--- a/igbinary.h
+++ b/igbinary.h
@@ -1,0 +1,7 @@
+#if PHP_MAJOR_VERSION == 5
+#include "src/php5/igbinary.h"
+#elif PHP_MAJOR_VERSION == 7
+#include "src/php7/igbinary.h"
+#else
+#error "Unsupported php version for igbinary build"
+#endif

--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,7 @@
   <dir name="/">
    <file name="config.m4" role="src" />
    <file name="config.w32" role="src" />
+   <file name="igbinary.h" role="src" />
    <file name="src/php5/hash.h" role="src" />
    <file name="src/php5/hash_si.c" role="src" />
    <file name="src/php5/igbinary.c" role="src" />

--- a/src/php5/igbinary.h
+++ b/src/php5/igbinary.h
@@ -10,12 +10,21 @@
 #ifndef IGBINARY_H
 #define IGBINARY_H
 #ifdef PHP_WIN32
-# include "ig_win32.h"
+# include "win32/php_stdint.h"
 #else
 # include <stdint.h>
 #endif
-#include "php.h"
 
+/* Forward declarations */
+struct zval;
+
+/* Constants / macro constants */
+/** Binary protocol version of igbinary. */
+#define IGBINARY_FORMAT_VERSION 0x00000002
+
+#define PHP_IGBINARY_VERSION "1.2.2-dev"
+
+/* Macros */
 #ifdef PHP_WIN32
 #	if defined(IGBINARY_EXPORTS) || (!defined(COMPILE_DL_IGBINARY))
 #		define IGBINARY_API __declspec(dllexport)
@@ -29,8 +38,6 @@
 #else
 #	define IGBINARY_API /* nothing special */
 #endif
-
-#define PHP_IGBINARY_VERSION "1.2.2-dev"
 
 /** Struct that contains pointers to memory allocation and deallocation functions.
  * @see igbinary_serialize_data

--- a/src/php5/php_igbinary.h
+++ b/src/php5/php_igbinary.h
@@ -10,6 +10,8 @@
 #ifndef PHP_IGBINARY_H
 #define PHP_IGBINARY_H
 
+#include "php.h"
+
 /** Module entry of igbinary. */
 extern zend_module_entry igbinary_module_entry;
 #define phpext_igbinary_ptr &igbinary_module_entry
@@ -60,9 +62,6 @@ PHP_FUNCTION(igbinary_unserialize);
 #else
 #define IGBINARY_G(v) (igbinary_globals.v)
 #endif
-
-/** Binary protocol version of igbinary. */
-#define IGBINARY_FORMAT_VERSION 0x00000002
 
 /** Backport macros from php 5.3 */
 #ifndef Z_ISREF_P

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -10,11 +10,21 @@
 #ifndef IGBINARY_H
 #define IGBINARY_H
 #ifdef PHP_WIN32
-# include "ig_win32.h"
+# include "win32/php_stdint.h"
 #else
 # include <stdint.h>
 #endif
-#include "php.h"
+
+/* Forward declarations. */
+struct zval;
+
+/* Constants and constant macros */
+/** Binary protocol version of igbinary. */
+#define IGBINARY_FORMAT_VERSION 0x00000002
+
+#define PHP_IGBINARY_VERSION "1.2.2-dev"
+
+/* Macros */
 
 #ifdef PHP_WIN32
 #	if defined(IGBINARY_EXPORTS) || (!defined(COMPILE_DL_IGBINARY))
@@ -29,8 +39,6 @@
 #else
 #	define IGBINARY_API /* nothing special */
 #endif
-
-#define PHP_IGBINARY_VERSION "1.2.2-dev"
 
 /** Struct that contains pointers to memory allocation and deallocation functions.
  * @see igbinary_serialize_data

--- a/src/php7/php_igbinary.h
+++ b/src/php7/php_igbinary.h
@@ -10,6 +10,8 @@
 #ifndef PHP_IGBINARY_H
 #define PHP_IGBINARY_H
 
+#include "php.h"
+
 /** Module entry of igbinary. */
 extern zend_module_entry igbinary_module_entry;
 #define phpext_igbinary_ptr &igbinary_module_entry
@@ -61,8 +63,6 @@ PHP_FUNCTION(igbinary_unserialize);
 #define IGBINARY_G(v) (igbinary_globals.v)
 #endif
 
-/** Binary protocol version of igbinary. */
-#define IGBINARY_FORMAT_VERSION 0x00000002
 
 /** Backport macros from php 5.3 */
 #ifndef Z_ISREF_P


### PR DESCRIPTION
config.m4: Use the command PHP_INSTALL_HEADERS to install headers globally in
ext/igbinary in the php installation directory.
(Aside: If it wasn't already installed, extensions could search for it in
pecl/igbinary as well, like this does for APCU?)

TODO: test in the Windows VM

config.w32: Use PHP_INSTALL_HEADERS to also include igbinary.h, which
just includes src/php{$PHP_MAJOR_VERSION}/igbinary.h

src/php*/igbinary.h: Make this into a standalone file.
Remove the dependency on the second file for declaring bool

- That may conflict with other extensions if those also declared bool.

Tested in php7.1