### PR TITLE
Fixes #72: Add a php_igbinary.h file to allow statically compiling php

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -79,7 +79,7 @@ if test "$PHP_IGBINARY" != "no"; then
   fi
 
   PHP_ADD_MAKEFILE_FRAGMENT(Makefile.bench)
-  PHP_INSTALL_HEADERS([ext/igbinary], [igbinary.h $subdir/igbinary.h])
+  PHP_INSTALL_HEADERS([ext/igbinary], [igbinary.h $subdir/igbinary.h php_igbinary.h $subdir/php_igbinary.h])
   PHP_NEW_EXTENSION(igbinary, $PHP_IGBINARY_SRC_FILES, $ext_shared,, $PHP_IGBINARY_CFLAGS)
   PHP_ADD_EXTENSION_DEP(igbinary, session, true)
   PHP_SUBST(IGBINARY_SHARED_LIBADD)

--- a/config.w32
+++ b/config.w32
@@ -36,5 +36,5 @@ if (PHP_IGBINARY == "yes") {
   configure_module_dirname = old_conf_dir;
   AC_DEFINE('HAVE_IGBINARY', 1, 'Have igbinary support', false);
   ADD_EXTENSION_DEP('igbinary', 'session');
-  PHP_INSTALL_HEADERS('ext/igbinary', 'igbinary.h ' + subdir + '\\igbinary.h');
+  PHP_INSTALL_HEADERS('ext/igbinary', 'igbinary.h php_igbinary.h ' + subdir + '\\igbinary.h ' + subdir + '\\php_igbinary.h'));
 }

--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,7 @@
    <file name="config.m4" role="src" />
    <file name="config.w32" role="src" />
    <file name="igbinary.h" role="src" />
+   <file name="php_igbinary.h" role="src" />
    <file name="src/php5/hash.h" role="src" />
    <file name="src/php5/hash_si.c" role="src" />
    <file name="src/php5/igbinary.c" role="src" />

--- a/php_igbinary.h
+++ b/php_igbinary.h
@@ -1,8 +1,8 @@
 #include "php_version.h"
 #if PHP_MAJOR_VERSION == 5
-#include "src/php5/igbinary.h"
+#include "ext/igbinary/src/php5/php_igbinary.h"
 #elif PHP_MAJOR_VERSION == 7
-#include "src/php7/igbinary.h"
+#include "ext/igbinary/src/php7/php_igbinary.h"
 #else
 #error "Unsupported php version for igbinary build"
 #endif


### PR DESCRIPTION
I can't think of any reasons for php_igbinary.h to be used by other
extensions, so not checking for pecl directory.