### PR TITLE
 Fix php7 calling __destruct if __wakeup has not yet been called

### DIFF
--- a/tests/igbinary_058.phpt
+++ b/tests/igbinary_058.phpt
@@ -1,0 +1,70 @@
+--TEST--
+Should not call __destruct if __wakeup throws an exception
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) { print "skip not able to set gc flags"; }
+?>
+--INI--
+igbinary.compact_strings = On
+--FILE--
+<?php
+class Thrower {
+	public $id;
+	public $throws;
+	public $dynamic;
+	public function __construct($id, $throws = false) {
+		$this->id = $id;
+		$this->throws = $throws;
+		$this->dynamic = "original";
+	}
+	public function __wakeup() {
+		printf("Calling __wakeup %s\n", $this->id);
+		$this->dynamic = "copy";
+		if ($this->throws) {
+			throw new Exception("__wakeup threw");
+		}
+	}
+
+	public function __destruct() {
+		printf("Calling __destruct %s dynamic=%s\n", $this->id, $this->dynamic);
+	}
+}
+function main() {
+	$a = new Thrower("a", true);
+	$serialized = igbinary_serialize($a);
+	try {
+		igbinary_unserialize($serialized);
+	} catch (Exception $e) {
+		printf("Caught %s\n", $e->getMessage());
+	}
+	$a = null;
+	print("Done a\n");
+	$b = new Thrower("b", false);
+	$serialized = igbinary_serialize($b);
+	$bCopy = igbinary_unserialize($serialized);
+	print("Unserialized b\n");
+	var_dump($bCopy);
+
+	$bCopy = null;
+	$b = null;
+	print("Done b\n");
+}
+main();
+--EXPECT--
+Calling __wakeup a
+Caught __wakeup threw
+Calling __destruct a dynamic=original
+Done a
+Calling __wakeup b
+Unserialized b
+object(Thrower)#2 (3) {
+  ["id"]=>
+  string(1) "b"
+  ["throws"]=>
+  bool(false)
+  ["dynamic"]=>
+  string(4) "copy"
+}
+Calling __destruct b dynamic=copy
+Calling __destruct b dynamic=original
+Done b

--- a/tests/igbinary_058b.phpt
+++ b/tests/igbinary_058b.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Should not call __destruct if __wakeup throws an exception (in arrays)
+--SKIPIF--
+<?php
+if (PHP_VERSION < 7) { print "skip not able to set gc flags"; }
+?>
+--INI--
+igbinary.compact_strings = On
+--FILE--
+<?php
+class Thrower {
+	public $id;
+	public $throws;
+	public $dynamic;
+	public function __construct($id, $throws = false) {
+		$this->id = $id;
+		$this->throws = $throws;
+		$this->dynamic = "original";
+	}
+	public function __wakeup() {
+		printf("Calling __wakeup %s\n", $this->id);
+		$this->dynamic = "copy";
+		if ($this->throws) {
+			throw new Exception("__wakeup threw for id " . $this->id);
+		}
+	}
+
+	public function __destruct() {
+		printf("Calling __destruct %s dynamic=%s\n", $this->id, $this->dynamic);
+	}
+}
+function main() {
+	$values = [
+		0      => new Thrower("a", false),
+		'foo'  => 'last',
+		'key1' => new Thrower("b", false),
+		2      => new Thrower("c", true),
+		'last' => new Thrower("d", false),
+	];
+	$serialized = igbinary_serialize($values);
+	$values = null;
+    printf("Going to unserialize\n");
+	try {
+		igbinary_unserialize($serialized);
+	} catch (Exception $e) {
+		printf("Caught %s\n", $e->getMessage());
+	}
+}
+main();
+--EXPECT--
+Calling __destruct a dynamic=original
+Calling __destruct b dynamic=original
+Calling __destruct c dynamic=original
+Calling __destruct d dynamic=original
+Going to unserialize
+Calling __wakeup a
+Calling __wakeup b
+Calling __wakeup c
+Calling __destruct a dynamic=copy
+Calling __destruct b dynamic=copy
+Caught __wakeup threw for id c


### PR DESCRIPTION
It's not possible to fix this in php5, there are no garbage collection flags.
This matches the built in serializer's behavior as of most recent branches of 7.0 and 7.1