### PR TITLE
Fixes #77: Build fails when compiling with `--with-session=shared`

### DIFF
--- a/src/php5/igbinary.c
+++ b/src/php5/igbinary.c
@@ -22,7 +22,7 @@
 #include "ext/standard/info.h"
 #include "ext/standard/php_var.h"
 
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 # include "ext/session/php_session.h"
 #endif /* HAVE_PHP_SESSION */
 
@@ -58,10 +58,10 @@
 #include <stddef.h>
 #include "hash.h"
 
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 /** Session serializer function prototypes. */
 PS_SERIALIZER_FUNCS(igbinary);
-#endif /* HAVE_PHP_SESSION */
+#endif /* HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION) */
 
 #if defined(HAVE_APC_SUPPORT) || defined(HAVE_APCU_SUPPORT)
 /** Apc serializer function prototypes */
@@ -246,7 +246,7 @@ zend_function_entry igbinary_functions[] = {
 #if ZEND_MODULE_API_NO >= 20050922
 static const zend_module_dep igbinary_module_deps[] = {
 	ZEND_MOD_REQUIRED("standard")
-#ifdef HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 	ZEND_MOD_REQUIRED("session")
 #endif
 #if defined(HAVE_APCU_SUPPORT)
@@ -307,7 +307,7 @@ PHP_MINIT_FUNCTION(igbinary) {
 	(void) module_number;
 	ZEND_INIT_MODULE_GLOBALS(igbinary, php_igbinary_init_globals, NULL);
 
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 	php_session_register_serializer("igbinary",
 		PS_SERIALIZER_ENCODE_NAME(igbinary),
 		PS_SERIALIZER_DECODE_NAME(igbinary));
@@ -355,7 +355,7 @@ PHP_MINFO_FUNCTION(igbinary) {
 #else
 	php_info_print_table_row(2, "igbinary APC serializer ABI", "no");
 #endif
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 	php_info_print_table_row(2, "igbinary session support", "yes");
 #else
 	php_info_print_table_row(2, "igbinary session support", "no");
@@ -496,7 +496,7 @@ PHP_FUNCTION(igbinary_serialize) {
 	RETVAL_STRINGL((char *)string, string_len, 0);
 }
 /* }}} */
-#ifdef HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 /* {{{ Serializer encode function */
 PS_SERIALIZER_ENCODE_FUNC(igbinary)
 {
@@ -601,7 +601,7 @@ PS_SERIALIZER_DECODE_FUNC(igbinary) {
 	return SUCCESS;
 }
 /* }}} */
-#endif /* HAVE_PHP_SESSION */
+#endif /* HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION) */
 
 #if defined(HAVE_APC_SUPPORT) || defined(HAVE_APCU_SUPPORT)
 /* {{{ apc_serialize function */

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -21,9 +21,9 @@
 #include "ext/standard/info.h"
 #include "ext/standard/php_var.h"
 
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 # include "ext/session/php_session.h"
-#endif /* HAVE_PHP_SESSION */
+#endif
 
 #include "ext/standard/php_incomplete_class.h"
 
@@ -49,10 +49,10 @@
 #include "hash.h"
 #include "hash_ptr.h"
 
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 /** Session serializer function prototypes. */
 PS_SERIALIZER_FUNCS(igbinary);
-#endif /* HAVE_PHP_SESSION */
+#endif /* HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION) */
 
 #if defined(HAVE_APCU_SUPPORT)
 /** Apc serializer function prototypes */
@@ -248,7 +248,7 @@ zend_function_entry igbinary_functions[] = {
 /* {{{ igbinary dependencies */
 static const zend_module_dep igbinary_module_deps[] = {
 	ZEND_MOD_REQUIRED("standard")
-#ifdef HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 	ZEND_MOD_REQUIRED("session")
 #endif
 #if defined(HAVE_APCU_SUPPORT)
@@ -306,7 +306,7 @@ PHP_MINIT_FUNCTION(igbinary) {
 	(void) module_number;
 	ZEND_INIT_MODULE_GLOBALS(igbinary, php_igbinary_init_globals, NULL);
 
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 	php_session_register_serializer("igbinary",
 		PS_SERIALIZER_ENCODE_NAME(igbinary),
 		PS_SERIALIZER_DECODE_NAME(igbinary));
@@ -353,7 +353,7 @@ PHP_MINFO_FUNCTION(igbinary) {
 #else
 	php_info_print_table_row(2, "igbinary APC serializer ABI", "no");
 #endif
-#if HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 	php_info_print_table_row(2, "igbinary session support", "yes");
 #else
 	php_info_print_table_row(2, "igbinary session support", "no");
@@ -557,7 +557,7 @@ PHP_FUNCTION(igbinary_serialize) {
 	efree(string);
 }
 /* }}} */
-#ifdef HAVE_PHP_SESSION
+#if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)
 /* {{{ Serializer encode function */
 PS_SERIALIZER_ENCODE_FUNC(igbinary)
 {
@@ -649,7 +649,7 @@ PS_SERIALIZER_DECODE_FUNC(igbinary) {
 	return SUCCESS;
 }
 /* }}} */
-#endif /* HAVE_PHP_SESSION */
+#endif /* HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION) */
 
 #if defined(HAVE_APCU_SUPPORT)
 /* {{{ apc_serialize function */


### PR DESCRIPTION
Consistently use #if HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION)

This is the same as other custom session handlers, e.g.
php-src/ext/wddx/wddx.c

This fixes igbinary builds where php was built with
--with-session=shared
(The default option was to have the session built statically into php,
which is why this was unnoticed in #14)

- If session is built as a shared library, custom session handlers
  cannot register themselves. If users want to use an igbinary session
  handler, session should be built statically. (Follows what built in
  extensions do)
- This check is the current convention for both php5 and php7 extensions.

This has been tested with two php builds.
`--with-session=shared` worked. `--enable-session` also worked.