### PR TITLE
Fixes #58:  Segfault in igbinary_unserialize from packed array (php7)

### DIFF
--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2013,6 +2013,13 @@ inline static int igbinary_unserialize_array(struct igbinary_unserialize_data *i
 	}
 	if ((flags & WANT_OBJECT) == 0) {
 		array_init_size(z_deref, n);
+		if (n > 0) {
+			/* (From var_unserializer.re): we can't convert from packed to hash during unserialization, because */
+			/*  references to some zvals might be kept in igsd->references (to support references). */
+			/* (This problem crops up when unserializing an array starting with key 0, and large number keys pointing to objects) */
+			/* TODO: Could consider adding packed arrays as a serialization type in the next igbinary format version, for efficiency. */
+			zend_hash_real_init(Z_ARRVAL_P(z_deref), 0);
+		}
 		/* add the new array to the list of unserialized references */
 		if (igsd_append_ref(igsd, z) == SIZE_MAX) {
 			return 1;

--- a/tests/igbinary_059.phpt
+++ b/tests/igbinary_059.phpt
@@ -1,0 +1,56 @@
+--TEST--
+igbinary_unserialize should never convert from packed array to hash when references exist (Bug #48)
+--SKIPIF--
+--FILE--
+<?php
+function main() {
+	$result = [];
+	// The default hash size is 16. If we start with 0, and aren't careful, the array would begin as a packed array,
+	// and the references would be invalidated when key 50 (>= 16) is added (converted to a hash), causing a segfault.
+	foreach ([0, 50] as $i) {
+	    $inner = new stdClass();
+	    $inner->a = $i;
+	    $result[0][0][$i] = $inner;
+	    $result[1][] = $inner;
+	}
+	$serialized = igbinary_serialize($result);
+	printf("%s\n", bin2hex(substr($serialized, 4)));
+	flush();
+	$unserialized = igbinary_unserialize($serialized);
+	var_dump($unserialized);
+}
+main();
+?>
+--EXPECTF--
+1402060014010600140206001708737464436c6173731401110161060006321a0014010e010632060114020600220306012204
+array(2) {
+  [0]=>
+  array(1) {
+    [0]=>
+    array(2) {
+      [0]=>
+      object(stdClass)#%d (1) {
+        ["a"]=>
+        int(0)
+      }
+      [50]=>
+      object(stdClass)#%d (1) {
+        ["a"]=>
+        int(50)
+      }
+    }
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    object(stdClass)#%d (1) {
+      ["a"]=>
+      int(0)
+    }
+    [1]=>
+    object(stdClass)#%d (1) {
+      ["a"]=>
+      int(50)
+    }
+  }
+}


### PR DESCRIPTION
The unserialized array starts out as packed if the first key is 0, but
may later become packed if subsequent keys are large, non-sequential, or
strings.
This makes the pointers in igsd->references invalid.
Fix this by always starting out non-empty arrays as hashes instead of
packed (like ext/standard/var_unserializer.re)