### PR TITLE
Fixes #51: Improve "unsupported version" message in unserialization

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -135,6 +135,7 @@
     <file name="igbinary_058.phpt" role="test" />
     <file name="igbinary_058b.phpt" role="test" />
     <file name="igbinary_059.phpt" role="test" />
+    <file name="igbinary_060.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />
@@ -173,6 +174,7 @@
 - (PHP 7) Don't call __destruct if __wakeup threw an exception (or __wakeup wasn't called yet)
 - Ports integration with other extensions to PHP 7.0 (session serialization, Memcached, Redis, APCu, etc.)
 - Fixes Windows PECL builds
+- Reword warnings for invalid header bytes of serialized data (in igbinary_unserialize).
    </notes>
   </release>
   <release>

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -37,6 +37,7 @@
 #include "igbinary.h"
 
 #include <assert.h>
+#include <ctype.h>
 
 #ifndef PHP_WIN32
 # include <inttypes.h>
@@ -1710,12 +1711,42 @@ inline static void igbinary_unserialize_data_deinit(struct igbinary_unserialize_
 	return;
 }
 /* }}} */
+/* {{{ igbinary_unserialize_header_emit_warning */
+/* Precondition: igsd->buffer_size >= 4 */
+inline static void igbinary_unserialize_header_emit_warning(struct igbinary_unserialize_data *igsd, int version) {
+	int i;
+	char buf[9], *it;
+	for (i = 0; i < 4; i++) {
+		if (!isprint((int)igsd->buffer[i])) {
+			if (version != 0 && (version & 0xff000000) == version) {
+				// Check if high order byte was set instead of low order byte
+				zend_error(E_WARNING, "igbinary_unserialize_header: unsupported version: %u, should be %u or %u (wrong endianness?)", (unsigned int) version, 0x00000001, (unsigned int) IGBINARY_FORMAT_VERSION);
+				return;
+			}
+			// Binary data, or a version number from a future release.
+			zend_error(E_WARNING, "igbinary_unserialize_header: unsupported version: %u, should be %u or %u", (unsigned int) version, 0x00000001, (unsigned int) IGBINARY_FORMAT_VERSION);
+			return;
+		}
+	}
+
+	for (it = buf, i = 0; i < 4; i++) {
+		char c = igsd->buffer[i];
+		if (c == '"' || c == '\\') {
+			*it++ = '\\';
+		}
+		*it++ = c;
+	}
+	*it = '\0';
+	zend_error(E_WARNING, "igbinary_unserialize_header: unsupported version: \"%s\"..., should begin with a binary version header of \"\\x00\\x00\\x00\\x01\" or \"\\x00\\x00\\x00\\x%02x\"", buf, (int)IGBINARY_FORMAT_VERSION);
+}
+/* }}} */
 /* {{{ igbinary_unserialize_header */
 /** Unserialize header. Check for version. */
 inline static int igbinary_unserialize_header(struct igbinary_unserialize_data *igsd TSRMLS_DC) {
 	uint32_t version;
 
 	if (igsd->buffer_offset + 4 >= igsd->buffer_size) {
+		zend_error(E_WARNING, "igbinary_unserialize_header: expected at least 5 bytes of data, got %u byte(s)", (unsigned int) igsd->buffer_size);
 		return 1;
 	}
 
@@ -1725,7 +1756,7 @@ inline static int igbinary_unserialize_header(struct igbinary_unserialize_data *
 	if (version == IGBINARY_FORMAT_VERSION || version == 0x00000001) {
 		return 0;
 	} else {
-		zend_error(E_WARNING, "igbinary_unserialize_header: unsupported version: %u, should be %u or %u", (unsigned int) version, 0x00000001, (unsigned int) IGBINARY_FORMAT_VERSION);
+		igbinary_unserialize_header_emit_warning(igsd, version);
 		return 1;
 	}
 }

--- a/tests/igbinary_060.phpt
+++ b/tests/igbinary_060.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Igbinary_unserialize_header warning
+--SKIPIF--
+--FILE--
+<?php
+function my_error_handler($errno, $errstr) {
+	printf("Logged: $errstr\n");
+}
+error_reporting(E_ALL);
+set_error_handler('my_error_handler');
+
+function test_igbinary_unserialize($data) {
+	$unserialized = igbinary_unserialize($data);
+	if ($unserialized !== null) {
+		printf("Expected null, got %s\n", var_export($unserialized, true));
+	}
+}
+
+test_igbinary_unserialize("a:0:{}");
+test_igbinary_unserialize('\\""\\{}');
+test_igbinary_unserialize("\x00\x00\x00\x01");
+test_igbinary_unserialize("\x00\x00\x00\x03\x00");
+test_igbinary_unserialize("\x00\x00\x00\xff\x00");
+test_igbinary_unserialize("\x02\x00\x00\x00\x00");
+--EXPECT--
+Logged: igbinary_unserialize_header: unsupported version: "a:0:"..., should begin with a binary version header of "\x00\x00\x00\x01" or "\x00\x00\x00\x02"
+Logged: igbinary_unserialize_header: unsupported version: "\\\"\"\\"..., should begin with a binary version header of "\x00\x00\x00\x01" or "\x00\x00\x00\x02"
+Logged: igbinary_unserialize_header: expected at least 5 bytes of data, got 4 byte(s)
+Logged: igbinary_unserialize_header: unsupported version: 3, should be 1 or 2
+Logged: igbinary_unserialize_header: unsupported version: 255, should be 1 or 2
+Logged: igbinary_unserialize_header: unsupported version: 33554432, should be 1 or 2 (wrong endianness?)


### PR DESCRIPTION
1. If all of the characters are printable ASCII,
   then print a different error
   message as a warning (Print the string representation instead of the
   little endian representation).
   This makes it more obvious if JSON, php, etc. serialization
   formats are incorrectly passed in.
   This adds appropriate backslashes.
2. If there are 1-4 bytes in the string,
   there previously wasn't a php warning, but this returned false.
   Emit one. (The smallest total serialized data length is (4+1) for things such as igbinary_serialize(null): "\x00\x00\x00\x02\x00")
   (This continues to not emit a warning for false or the empty string)