### PR TITLE
Fix php 5.2 compatibility - add macros EXPECTED and UNEXPECTED

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -51,6 +51,7 @@
    <file name="src/php5/hash_si_ptr.c" role="src" />
    <file name="src/php5/igbinary.c" role="src" />
    <file name="src/php5/igbinary.h" role="src" />
+   <file name="src/php5/igbinary_macros.h" role="src" />
    <file name="src/php5/php_igbinary.h" role="src" />
    <file name="src/php5/ig_win32.h" role="src" />
    <file name="src/php5/apc_serializer.h" role="src" />

--- a/src/php5/hash_si.c
+++ b/src/php5/hash_si.c
@@ -18,6 +18,7 @@
 #include <assert.h>
 
 #include "hash.h"
+#include "igbinary_macros.h"
 #include "zend.h"
 
 /* {{{ nextpow2 */

--- a/src/php5/igbinary_macros.h
+++ b/src/php5/igbinary_macros.h
@@ -1,0 +1,19 @@
+/*
+  +----------------------------------------------------------------------+
+  | See COPYING file for further copyright information                   |
+  +----------------------------------------------------------------------+
+  | See CREDITS for contributors                                         |
+  +----------------------------------------------------------------------+
+*/
+#ifndef PHP_IGBINARY_MACROS_H
+#define PHP_IGBINARY_MACROS_H
+
+// PHP 5.2 doesn't define EXPECTED or UNEXPECTED in Zend/zend.h.
+#ifndef EXPECTED
+# define EXPECTED(expr) (expr)
+#endif
+#ifndef UNEXPECTED
+# define UNEXPECTED(expr) (expr)
+#endif
+
+#endif

--- a/src/php5/php_igbinary.h
+++ b/src/php5/php_igbinary.h
@@ -11,6 +11,7 @@
 #define PHP_IGBINARY_H
 
 #include "php.h"
+#include "igbinary_macros.h"
 
 /** Module entry of igbinary. */
 extern zend_module_entry igbinary_module_entry;


### PR DESCRIPTION
Those macros did not exist in headers of php 5.2 installations,
so there was an "Undefined symbol" error.
All tests pass for php 5.2.17 after this commit.