### PR TITLE
Fix bug in #94: Don't replace zend macros for EXPECTED in php 5.3+

### DIFF
--- a/src/php5/hash_si.c
+++ b/src/php5/hash_si.c
@@ -18,8 +18,9 @@
 #include <assert.h>
 
 #include "hash.h"
-#include "igbinary_macros.h"
 #include "zend.h"
+
+#include "igbinary_macros.h"
 
 /* {{{ nextpow2 */
 /** Next power of 2.

--- a/src/php5/igbinary_macros.h
+++ b/src/php5/igbinary_macros.h
@@ -8,7 +8,9 @@
 #ifndef PHP_IGBINARY_MACROS_H
 #define PHP_IGBINARY_MACROS_H
 
-// PHP 5.2 doesn't define EXPECTED or UNEXPECTED in Zend/zend.h.
+/* Require zend.h first, so that we are absolutely importing this header doesn't override EXPECTED or UNEXPECTED. */
+#include "zend.h"
+/* PHP 5.2 doesn't define EXPECTED or UNEXPECTED in Zend/zend.h. */
 #ifndef EXPECTED
 # define EXPECTED(expr) (expr)
 #endif

--- a/src/php5/php_igbinary.h
+++ b/src/php5/php_igbinary.h
@@ -11,7 +11,6 @@
 #define PHP_IGBINARY_H
 
 #include "php.h"
-#include "igbinary_macros.h"
 
 /** Module entry of igbinary. */
 extern zend_module_entry igbinary_module_entry;
@@ -88,8 +87,10 @@ PHP_FUNCTION(igbinary_unserialize);
 #ifndef Z_ADDREF_PP
 #define Z_ADDREF_PP(ppz)               Z_ADDREF_P(*(ppz))
 #endif
-#endif /* PHP_IGBINARY_H */
 
+/** Add macros missing from php 5.2 */
+#include "igbinary_macros.h"
+#endif /* PHP_IGBINARY_H */
 
 /*
  * Local variables:


### PR DESCRIPTION
Accidentally used the fallback macros all of the time.
PR 94 would be slightly less efficient, but still correct.