### PR TITLE
Add current php 7.0 Windows build status (AppVeyor) to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ igbinary
 ========
 
 [![Build Status](https://travis-ci.org/igbinary/igbinary.svg?branch=master)](https://travis-ci.org/igbinary/igbinary)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/suhkkumj1yh9dgan?svg=true)](https://ci.appveyor.com/project/TysonAndre/igbinary-bemsx)
 
 Igbinary is a drop in replacement for the standard php serializer. Instead of
 time and space consuming textual representation, igbinary stores php data

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 # Based on php-ds's appveyor config.
 # This tests against the latest stable minor version of PHP 7 (Currently 7.0)
+# The project name is the same as the build id used, e.g. https://www.appveyor.com/docs/environment-variables/
 
 version: '{branch}.{build}'
 install:
 - cmd: choco feature enable -n=allowGlobalConfirmation
 - cmd: cinst wget
-- cmd: mkdir C:\projects\igbinary\bin
+- cmd: mkdir %APPVEYOR_BUILD_FOLDER%\bin
 build_script:
 - cmd: >-
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
@@ -20,7 +21,7 @@ build_script:
 
     mkdir C:\projects\php-src\ext\igbinary
 
-    xcopy C:\projects\igbinary C:\projects\php-src\ext\igbinary /s /e /y
+    xcopy %APPVEYOR_BUILD_FOLDER% C:\projects\php-src\ext\igbinary /s /e /y
 
     wget http://windows.php.net/downloads/php-sdk/deps-7.0-vc14-x86.7z
 
@@ -30,7 +31,7 @@ build_script:
 
     buildconf.bat
 
-    configure.bat --disable-all --enable-session --enable-cli --enable-cgi --enable-igbinary --enable-json --with-config-file-scan-dir=C:\projects\extension\bin\modules.d --with-prefix=C:\projects\igbinary\bin --with-php-build=deps
+    configure.bat --disable-all --enable-session --enable-cli --enable-cgi --enable-igbinary --enable-json --with-config-file-scan-dir=C:\projects\extension\bin\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\bin --with-php-build=deps
 
     nmake
 
@@ -53,7 +54,7 @@ test_script:
 #> Command exited with code 2
 #> nmake install
 
-# mkdir C:\projects\igbinary\bin\modules.d
+# mkdir %APPVEYOR_BUILD_FOLDER%\bin\modules.d
 
-# echo extension=igbinary.dll > C:\projects\igbinary\bin\modules.d\php.ini
+# echo extension=igbinary.dll > %APPVEYOR_BUILD_FOLDER%\bin\modules.d\php.ini
 


### PR DESCRIPTION
Use environment variables in appveyor.yml The project name isn't "igbinary" in some cases, it might just have that prefix.
  
Note: The link can't be changed to project group (or at all) until
https://github.com/appveyor/ci issue 678 is fixed.
    
However, it could be changed manually in the database by filing an issue with the appveyor project