### PR TITLE
Make AppVeyor build fail if there are 1 or more failing tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,8 @@ build_script:
 
 test_script:
 - cmd: cd C:\projects\php-src
+- cmd: set NO_INTERACTION=1
+- cmd: set REPORT_EXIT_STATUS=1
 - cmd: nmake test TESTS=C:\projects\php-src\ext\igbinary\tests
 
 #artifacts:


### PR DESCRIPTION
Previously, `nmake test` would always exit with return code 0.
The environment variable REPORT_EXIT_STATUS fixes that.