### PR TITLE
Fixes #103: igbinary should call __wakeup when decoding sessions(php7)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,8 @@
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
 - Compatible with PHP 5.2 - 7.0
+- Fixes bug in session decoder not calling wakeup in php 7.0+
+- (Enhancement) Reuses identical strings when unserializing objects and arrays in php 7.0+
  </notes>
  <contents>
   <dir name="/">
@@ -144,6 +146,7 @@
     <file name="igbinary_058b.phpt" role="test" />
     <file name="igbinary_059.phpt" role="test" />
     <file name="igbinary_060.phpt" role="test" />
+    <file name="igbinary_061.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />
@@ -176,6 +179,9 @@
    </stability>
    <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
    <notes>
+- Compatible with PHP 5.2 - 7.0
+- Fixes bug in session decoder not calling wakeup in php 7.0+
+- (Enhancement) Reuses identical strings when unserializing objects and arrays in php 7.0+
    </notes>
   </release>
   <release>

--- a/tests/igbinary_061.phpt
+++ b/tests/igbinary_061.phpt
@@ -1,0 +1,52 @@
+--TEST--
+igbinary session decoder should call __wakup
+--INI--
+date.timezone=UTC
+session.serialize_handler=igbinary
+--SKIPIF--
+<?php
+if (!extension_loaded('session')) {
+	exit('skip session extension not loaded');
+}
+
+ob_start();
+phpinfo(INFO_MODULES);
+$str = ob_get_clean();
+
+$array = explode("\n", $str);
+$array = preg_grep('/^igbinary session support.*yes/', $array);
+if (!$array) {
+	exit('skip igbinary session handler not available');
+}
+
+--FILE--
+<?php
+
+class A {
+	public $b;
+	public $c;
+	public function __wakeup() {
+		$this->c = $this->b . 'OnWakeup';
+	}
+}
+
+error_reporting(E_ALL);
+// Start session
+session_start();
+// The serialization of DateTime varies in php5 and php 7.
+$_SESSION['date'] = new \DateTime('@1234567890');
+$a = new A();
+$a->b = 'value';
+$_SESSION['a'] = $a;
+var_dump($_SESSION['date']->getTimestamp());
+$mydata = session_encode();
+unset($_SESSION['date']);
+var_dump(session_decode($mydata));
+var_dump($_SESSION['date']->getTimestamp());
+var_dump($_SESSION['a']->c);
+?>
+--EXPECT--
+int(1234567890)
+bool(true)
+int(1234567890)
+string(13) "valueOnWakeup"


### PR DESCRIPTION
This is the only other public method using igbinary_unserialize.
I forgot to call igbinary_finish_wakeup in the session decoder
when fixing other bugs related to __wakeup.

Add a test to catch this.

And update package.xml notes.