### PR TITLE
Add php 7.1 to the build matrix. Exclude some build matrix entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,38 @@
 language: php
 
 php:
+  - 7.1
   - 7.0
   - 5.6
   - 5.5
   - 5.4
   - 5.3
+
+# For unsupported versions(5.3-5.5), run minimal tests to cover 32-bit, 64-bit, and clang
+# Exclude everything else.
+# Allow 7.1 to fail while still a release candidate (Will change shortly)
+matrix:
+  allow_failures:
+  - php: 7.1
+  exclude:
+  - php: 5.3
+    env: CC=clang   CFLAGS="-g -O0"
+  - php: 5.3
+    env: CC=gcc-4.6 CFLAGS=""
+  - php: 5.3
+    env: CC=gcc-4.6 CFLAGS="-g -O0 -fstack-protector -fstack-protector-all"
+  - php: 5.4
+    env: CC=clang   CFLAGS="-g -O0"
+  - php: 5.4
+    env: CC=gcc-4.6 CFLAGS=""
+  - php: 5.4
+    env: CC=gcc-4.6 CFLAGS="-g -O0 -fstack-protector -fstack-protector-all"
+  - php: 5.5
+    env: CC=clang   CFLAGS="-g -O0"
+  - php: 5.5
+    env: CC=gcc-4.6 CFLAGS=""
+  - php: 5.5
+    env: CC=gcc-4.6 CFLAGS="-g -O0 -fstack-protector -fstack-protector-all"
 
 cache:
   directories:

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -12,14 +12,20 @@ if [ -x $PHP_INSTALL_DIR/bin/php ] ; then
 	echo "PHP $PHP_CUSTOM_VERSION already installed and in cache at $PHP_INSTALL_DIR";
 	exit 0
 fi
+PHP_CUSTOM_NORMAL_VERSION=${PHP_CUSTOM_VERSION//RC[0-9]/}
+PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 # Remove cache if it somehow exists
 if [ "x${TRAVIS:-0}" != "x" ]; then
 	rm -rf $HOME/travis_cache/
 fi
 # Otherwise, put a minimal installation inside of the cache.
 PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-curl --verbose https://secure.php.net/distributions/$PHP_TAR_FILE -o $PHP_TAR_FILE
-# If we decide to support 7.1.0, it would be `curl --verbose https://downloads.php.net/~davey/php-7.1.0RC3.tar.bz2 -o $PHP_TAR_FILE`
+if [ "$PHP_CUSTOM_NORMAL_VERSION" != "7.1.0" ] ; then
+	curl --verbose https://secure.php.net/distributions/$PHP_TAR_FILE -o $PHP_TAR_FILE
+else
+	curl --verbose https://downloads.php.net/~krakjoe/php-7.1.0RC6.tar.bz2 -o $PHP_TAR_FILE
+	PHP_FOLDER="php-7.1.0RC6"
+fi
 tar xjf $PHP_TAR_FILE
 
 pushd $PHP_FOLDER


### PR DESCRIPTION
Leave 3 minimal entries to cover
32-bit, 64-bit, gcc, and clang in php 5.3-5.5