### PR TITLE
Fix the config.m4 pecl builds

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -43,7 +43,7 @@ if test "$PHP_IGBINARY" != "no"; then
     apc_inc_path="$phpincludedir"
     AC_MSG_RESULT([APCU in $apc_inc_path])
     AC_DEFINE(HAVE_APCU_SUPPORT,1,[Whether to enable apcu support])
-  elif test -f "$phpincludedir/ext/apc/apc_serializer.h"; then
+  elif test "$subdir" == src/php5 && test -f "$phpincludedir/ext/apc/apc_serializer.h"; then
     apc_inc_path="$phpincludedir"
     AC_MSG_RESULT([APC in $apc_inc_path])
     AC_DEFINE(HAVE_APC_SUPPORT,1,[Whether to enable apc support])
@@ -82,5 +82,6 @@ if test "$PHP_IGBINARY" != "no"; then
   PHP_INSTALL_HEADERS([ext/igbinary], [igbinary.h $subdir/igbinary.h php_igbinary.h $subdir/php_igbinary.h])
   PHP_NEW_EXTENSION(igbinary, $PHP_IGBINARY_SRC_FILES, $ext_shared,, $PHP_IGBINARY_CFLAGS)
   PHP_ADD_EXTENSION_DEP(igbinary, session, true)
+  PHP_ADD_BUILD_DIR($abs_builddir/$subdir, 1)
   PHP_SUBST(IGBINARY_SHARED_LIBADD)
 fi


### PR DESCRIPTION
It was missing the PHP_ADD_BUILD_DIR directive.
Verified that `pecl build` worked when the package was downloaded
using pecl download and this change was made.

Fixes #111 whenever this is released

Also, forgot to check if current php version is 5.x when checking for
APC(not APCu) support elsewhere in config.m4