### PR TITLE
Fixes main/internal_functions_cli.c ... error: ‘phpext_igbinary_ptr’ …

### DIFF
--- a/igbinary.h
+++ b/igbinary.h
@@ -1,3 +1,5 @@
+#ifndef PHPEXT_IGBINARY_BASE_IGBINARY_H
+#define PHPEXT_IGBINARY_BASE_IGBINARY_H
 #include "php_version.h"
 #if PHP_MAJOR_VERSION == 5
 #include "src/php5/igbinary.h"
@@ -5,4 +7,5 @@
 #include "src/php7/igbinary.h"
 #else
 #error "Unsupported php version for igbinary build"
+#endif
 #endif

--- a/php_igbinary.h
+++ b/php_igbinary.h
@@ -1,3 +1,5 @@
+#ifndef PHPEXT_IGBINARY_BASE_PHP_IGBINARY_H
+#define PHPEXT_IGBINARY_BASE_PHP_IGBINARY_H
 #include "php_version.h"
 #if PHP_MAJOR_VERSION == 5
 #include "ext/igbinary/src/php5/php_igbinary.h"
@@ -5,4 +7,18 @@
 #include "ext/igbinary/src/php7/php_igbinary.h"
 #else
 #error "Unsupported php version for igbinary build"
+#endif
+
+/**
+ * The below line is redundant and identical to php5 and php7's line
+ * (and just mentioning phpext_ in a comment is sufficient).
+ * This block is only here to make php-src/build/print_include.awk include this file,
+ * when igbinary is placed in php-src/ext/igbinary/ (instead of compiled separately with `phpize; ...`)
+ */
+#ifndef phpext_igbinary_ptr
+extern zend_module_entry igbinary_module_entry;
+#define phpext_igbinary_ptr &igbinary_module_entry
+#endif
+/** End line needed for putting igbinary in php-src/ext/igbinary to work */
+
 #endif


### PR DESCRIPTION
…undeclared here

Fixes issue #117

Fix the magic phpext_ source file checking.
Mentioning "phpext_" anywhere in a top level *.h file is sufficient
to get the php_igbinary.h header file added.
After that's done, compilation works in a centos 7 VM
(but some tests related to __wakeup fail in php 7.1.3,
for what seem like unrelated reasons)

This affects users who place igbinary in php-src/ext/igbinary
(instead of compiling it afterwards)

- See https://github.com/php/php-src/blob/PHP-7.1/build/print_include.awk - The line `/phpext_/` means to execute that block of code on any lines which contain the substring "phpext_", and it gets run once per file