### PR TITLE
Check for IS_UNDEF (zval type 0) in igbinary_serialize_zval

### DIFF
--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -1632,6 +1632,10 @@ static int igbinary_serialize_zval(struct igbinary_serialize_data *igsd, zval *z
 			return igbinary_serialize_long(igsd, Z_LVAL_P(z) TSRMLS_CC);
 		case IS_NULL:
 			return igbinary_serialize_null(igsd TSRMLS_CC);
+		case IS_UNDEF:
+			// As of php 7.1.3, started seeing "zval has unknown type 0"
+			zend_error(E_WARNING, "igbinary_serialize_zval: zval has unexpected type IS_UNDEF(0)");
+			return igbinary_serialize_null(igsd TSRMLS_CC);
 		case IS_TRUE:
 			return igbinary_serialize_bool(igsd, 1 TSRMLS_CC);
 		case IS_FALSE:


### PR DESCRIPTION
Noticed 4 errors (out of a large number of errors) for unexpected zval type 0.
Not sure of the cause yet, but this is a valid zval type, and shouldn't
result in a fatal error.

This started happening after upgrading from 7.1.2 to 7.1.3

This only affects php 7.

- It could be related to a combination of (object)$array, unset(), and
  get_object_vars()
- It may be related to unsetting properties of an object.
- It may be related to references to undefined objects.
- It could be related to garbage collection, or changes to the way
  references to global variables work.