### PR TITLE
Don't call __wakeup if Serializable::unserialize() was used to build …

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+2.0.4 ???
+========
+* Fixes bug #129: Should not call __wakeup() on data which was created by Serializable::unserialize()
+
 2.0.3 2017-03-31
 ========
 * Fixes bug #126: Fatal error: "igbinary_serialize_zval: zval has unknown type 0" (IS_UNDEF)

--- a/package.xml
+++ b/package.xml
@@ -147,6 +147,7 @@
     <file name="igbinary_059.phpt" role="test" />
     <file name="igbinary_060.phpt" role="test" />
     <file name="igbinary_061.phpt" role="test" />
+    <file name="igbinary_062.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />

--- a/src/php5/igbinary.c
+++ b/src/php5/igbinary.c
@@ -2137,6 +2137,7 @@ inline static int igbinary_unserialize_object(struct igbinary_unserialize_data *
 	int r;
 
 	bool incomplete_class = false;
+	bool is_from_serialized_data = false;
 
 	zval *user_func;
 	zval *retval_ptr;
@@ -2240,6 +2241,7 @@ inline static int igbinary_unserialize_object(struct igbinary_unserialize_data *
 		case igbinary_type_object_ser8:
 		case igbinary_type_object_ser16:
 		case igbinary_type_object_ser32:
+			is_from_serialized_data = true;
 			r = igbinary_unserialize_object_ser(igsd, t, z, ce TSRMLS_CC);
 			break;
 		default:
@@ -2251,7 +2253,7 @@ inline static int igbinary_unserialize_object(struct igbinary_unserialize_data *
 		return r;
 	}
 
-	if (Z_OBJCE_PP(z) != PHP_IC_ENTRY && zend_hash_exists(&Z_OBJCE_PP(z)->function_table, "__wakeup", sizeof("__wakeup"))) {
+	if (!is_from_serialized_data && Z_OBJCE_PP(z) != PHP_IC_ENTRY && zend_hash_exists(&Z_OBJCE_PP(z)->function_table, "__wakeup", sizeof("__wakeup"))) {
 		INIT_PZVAL(&f);
 		ZVAL_STRINGL(&f, "__wakeup", sizeof("__wakeup") - 1, 0);
 		call_user_function_ex(CG(function_table), z, &f, &h, 0, 0, 1, NULL TSRMLS_CC);

--- a/tests/igbinary_061.phpt
+++ b/tests/igbinary_061.phpt
@@ -1,5 +1,5 @@
 --TEST--
-igbinary session decoder should call __wakup
+igbinary session decoder should call __wakeup
 --INI--
 date.timezone=UTC
 session.serialize_handler=igbinary

--- a/tests/igbinary_062.phpt
+++ b/tests/igbinary_062.phpt
@@ -1,0 +1,54 @@
+--TEST--
+igbinary should not call __wakeup() if Serializable::unserialize was used to unserialize the object data (like `unserialize`)
+--FILE--
+<?php
+
+error_reporting(E_ALL);
+class A implements Serializable {
+   public $prop = 'value';
+   public function serialize() {
+       echo "In serialize " . $this->prop . "\n";
+       return $this->prop;
+   }
+   public function unserialize($data) {
+       echo "In unserialize $data\n";
+       $this->prop = $data;
+   }
+
+   public function __wakeup() {
+       echo "In __wakeup, unexpectedly\n";
+   }
+}
+
+function testA() {
+  $a = new A();
+  $a->prop = 'other';
+  $ser = serialize($a);
+  $b = unserialize($ser);
+  var_dump($b);
+
+  $c = new A();
+  $c->prop = 'igprop';
+  $serC = igbinary_serialize($c);
+  echo bin2hex($serC) . "\n";
+  $d = igbinary_unserialize($serC);
+  var_dump($d);
+
+}
+
+testA();
+?>
+--EXPECTF--
+In serialize other
+In unserialize other
+object(A)#%d (1) {
+  ["prop"]=>
+  string(5) "other"
+}
+In serialize igprop
+000000021701411d06696770726f70
+In unserialize igprop
+object(A)#%d (1) {
+  ["prop"]=>
+  string(6) "igprop"
+}


### PR DESCRIPTION
…object

This matches the behavior of `unserialize` to `igbinary_unserialize()`

Fixes #129