### PR TITLE
Fix test suite for PHP  7.2

### DIFF
--- a/tests/igbinary_019.phpt
+++ b/tests/igbinary_019.phpt
@@ -17,7 +17,7 @@ function test($type, $variable, $test) {
 	echo "\n";
 }
 
-function __autoload($classname) {
+function test_autoload($classname) {
 	class Obj {
 		var $a;
 		var $b;
@@ -28,6 +28,7 @@ function __autoload($classname) {
 		}
 	}
 }
+spl_autoload_register("test_autoload");
 
 test('autoload', '0000000217034f626a140211016106011101620602', false);
 

--- a/tests/igbinary_unserialize_v1_compatible.phpt
+++ b/tests/igbinary_unserialize_v1_compatible.phpt
@@ -61,11 +61,11 @@ $data = array(
 		'version' => 1,
 	),
 	array(
-		'var' => 'O:8:"stdClass":4:{i:0;i:1;i:1;i:2;i:2;i:3;i:3;i:4;}',
-		'var_e' => (object)array(1, 2, 3, 4),
+		'var' => 'O:8:"stdClass":4:{s:1:"a";i:1;s:1:"b";i:2;s:1:"c";i:3;s:1:"d";i:4;}',
+		'var_e' => (object)array("a"=>1, "b"=>2, "c"=>3, "d"=>4),
 		'type' => 'object',
 		'description' => 'object',
-		'data' => 'AAAAARcIc3RkQ2xhc3MUBAYABgEGAQYCBgIGAwYDBgQ=',
+		'data' => 'AAAAAhcIc3RkQ2xhc3MUBBEBYQYBEQFiBgIRAWMGAxEBZAYE',
 		'version' => 1,
 	),
 	array(


### PR DESCRIPTION
The fix for igbinary_unserialize_v1_compatible.phpt is not obvious...

Small behavior change in 74.2 explaining failure of this test

```
$ php71 -r 'var_dump((object)[1,2,3,4]);'
object(stdClass)#1 (4) {
  [0]=>
  int(1)
  [1]=>
  int(2)
  [2]=>
  int(3)
  [3]=>
  int(4)
}

$ php72 -r 'var_dump((object)[1,2,3,4]);'
object(stdClass)#1 (4) {
  ["0"]=>
  int(1)
  ["1"]=>
  int(2)
  ["2"]=>
  int(3)
  ["3"]=>
  int(4)
}
```

BTW, igbinary works
```
$ php71  -r 'var_dump($x=(object)array(1,2,3,4), base64_encode($a=igbinary_serialize($x)), igbinary_unserialize($a));'
object(stdClass)#1 (4) {
  [0]=>
  int(1)
  [1]=>
  int(2)
  [2]=>
  int(3)
  [3]=>
  int(4)
}
string(44) "AAAAAhcIc3RkQ2xhc3MUBAYABgEGAQYCBgIGAwYDBgQ="
object(stdClass)#2 (4) {
  [0]=>
  int(1)
  [1]=>
  int(2)
  [2]=>
  int(3)
  [3]=>
  int(4)
}

$ php72 -r 'var_dump($x=(object)array(1,2,3,4), base64_encode($a=igbinary_serialize($x)), igbinary_unserialize($a));'
object(stdClass)#1 (4) {
  ["0"]=>
  int(1)
  ["1"]=>
  int(2)
  ["2"]=>
  int(3)
  ["3"]=>
  int(4)
}
string(48) "AAAAAhcIc3RkQ2xhc3MUBBEBMAYBEQExBgIRATIGAxEBMwYE"
object(stdClass)#2 (4) {
  ["0"]=>
  int(1)
  ["1"]=>
  int(2)
  ["2"]=>
  int(3)
  ["3"]=>
  int(4)
}

```

So the fix is mostly a workaround to avoid object with only numerical property.