### PR TITLE
Update CI checks for php 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
-# When updating 7.2.0X, update the download URL in ci/install_php_custom.sh as well,
-# so that 32-bit testing will work.
+# TODO: Periodically update the download URL for 7.2.0 betas and RCs in ci/install_php_custom.sh as well,
+# so that 32-bit testing will work the same way.
 php:
-  - 7.2.0alpha2
+  - 7.2
   - 7.1
   - 7.0
   - 5.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # Based on php-ds's appveyor config.
-# This tests against the latest stable minor version of PHP 7 (Currently 7.0)
+# This tests against the latest stable minor version of PHP 7 (Currently 7.1)
 # The project name is the same as the build id used, e.g. https://www.appveyor.com/docs/environment-variables/
 
 version: '{branch}.{build}'

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -34,14 +34,14 @@ PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
 if [ "$PHP_CUSTOM_NORMAL_VERSION" != "7.2.0" ] ; then
     curl --verbose https://secure.php.net/distributions/$PHP_TAR_FILE -o $PHP_TAR_FILE
 else
-    curl --verbose https://downloads.php.net/~pollita/php-7.2.0alpha2.tar.bz2 -o $PHP_TAR_FILE
-    PHP_FOLDER="php-7.2.0alpha2"
+    curl --verbose https://downloads.php.net/~pollita/php-7.2.0RC2.tar.bz2 -o $PHP_TAR_FILE
+    PHP_FOLDER="php-7.2.0beta2"
 fi
 
 tar xjf $PHP_TAR_FILE
 
 pushd $PHP_FOLDER
-./configure $PHP_CONFIGURE_ARGS --prefix="$PHP_INSTALL_DIR"
+./configure $PHP_CONFIGURE_ARGS --without-pear --prefix="$PHP_INSTALL_DIR"
 make -j5
 make install
 popd


### PR DESCRIPTION
`master` of php-src now contains php 7.3.
Wait for an alpha before starting to use CI tests of php 7.3.

Test 32-bit builds with newer php 7.2.0beta2