### PR TITLE
Stop trying to build php 5.3 in trusty on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 # When updating 7.2.0X, update the download URL in ci/install_php_custom.sh as well,
 # so that 32-bit testing will work.
+# PHP 5.3 is still supported in igbinary releases; it's just that travis can't/won't build php 5.3 in trusty.
 php:
   - master
   - 7.2
@@ -10,18 +11,11 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
 
-# For unsupported versions(5.3-5.5), run minimal tests to cover 32-bit, 64-bit, and clang
+# For unsupported versions(5.4-5.5), run minimal tests to cover 32-bit, 64-bit, and clang
 # Exclude everything else.
 matrix:
   exclude:
-  - php: 5.3
-    env: CC=clang   CFLAGS="-g -O0"
-  - php: 5.3
-    env: CC=gcc-4.8 CFLAGS=""
-  - php: 5.3
-    env: CC=gcc-4.8 CFLAGS="-g -O0 -fstack-protector -fstack-protector-all"
   - php: 5.4
     env: CC=clang   CFLAGS="-g -O0"
   - php: 5.4
@@ -78,8 +72,6 @@ before_script:
 script:
   - phpize
   - ./configure --enable-igbinary
-  # Fix not failing makes in php 5.2 and 5.3
-  - perl -i -pe 's/\-\@if/\@if/' Makefile
   - make
   - REPORT_EXIT_STATUS=1 NO_INTERACTION=1 make test
   # For most travis builds, re-run `make test` with valgrind.


### PR DESCRIPTION
PHP 5.3 is still supported by igbinary,
travis is just no longer able to build php 5.3.