### PR TITLE
Fix bug in gcc detection, use faster gcc flags by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,9 @@
-2.0.5 2017-??-??
+2.0.5 2017-?-? (dev)
 ========
 * Slightly improve performance when unserializing objects.
 * Update unserialization of integer object keys for php 7.2: Make those keys accessible when unserializing.
+* Properly pick up presence of gcc for default compiler flags (`cc --version` doesn't contain gcc).
+  Add -O2 to default gcc compiler flags.
 
 2.0.4 2017-04-14
 ========

--- a/config.m4
+++ b/config.m4
@@ -59,20 +59,20 @@ if test "$PHP_IGBINARY" != "no"; then
 
   dnl GCC
   AC_MSG_CHECKING(compiler type)
-  if test ! -z "`$CC --version | grep -i GCC`"; then
-    AC_MSG_RESULT(gcc)
-    if test -z "`echo $CFLAGS | grep -- -O0`"; then
-      PHP_IGBINARY_CFLAGS="$CFLAGS -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -Winline -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
-    fi
-  elif test ! -z "`$CC --version | grep -i ICC`"; then
-    AC_MSG_RESULT(icc)
-    if test -z "`echo $CFLAGS | grep -- -O0`"; then
-      PHP_IGBINARY_CFLAGS="$CFLAGS -no-prec-div -O3 -x0 -unroll2"
-    fi
-  elif test ! -z "`$CC --version | grep -i CLANG`"; then
+  if test ! -z "`$CC --version | grep -i CLANG`"; then
     AC_MSG_RESULT(clang)
     if test -z "`echo $CFLAGS | grep -- -O0`"; then
       PHP_IGBINARY_CFLAGS="$CFLAGS -Wall -O2"
+    fi
+  elif test "$GCC" = yes; then
+    AC_MSG_RESULT(gcc)
+    if test -z "`echo $CFLAGS | grep -- '-O[0123]'`"; then
+      PHP_IGBINARY_CFLAGS="$CFLAGS -O2 -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -Winline -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
+    fi
+  elif test "$ICC" = yes; then
+    AC_MSG_RESULT(icc)
+    if test -z "`echo $CFLAGS | grep -- -O0`"; then
+      PHP_IGBINARY_CFLAGS="$CFLAGS -no-prec-div -O3 -x0 -unroll2"
     fi
   else
     AC_MSG_RESULT(other)

--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,7 @@
  <date>2017-03-31</date>
  <time>16:00:00</time>
  <version>
-  <release>2.0.4</release>
+  <release>2.0.5</release>
   <api>1.1.1</api>
  </version>
  <stability>
@@ -163,6 +163,19 @@
  <providesextension>igbinary</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2017-10-11</date>
+   <time>16:00:00</time>
+   <version>
+    <release>2.0.5-dev</release>
+    <api>1.1.1</api>
+   </version>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Properly pick up presence of gcc for default compiler flags (`cc --version` doesn't contain gcc).
+  Add -O2 to default gcc compiler flags.
+   </notes>
+  </release>
   <release>
    <date>2017-04-14</date>
    <time>16:00:00</time>

--- a/src/php5/igbinary.h
+++ b/src/php5/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "2.0.4"
+#define PHP_IGBINARY_VERSION "2.0.5-dev"
 
 /* Macros */
 #ifdef PHP_WIN32

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "2.0.4"
+#define PHP_IGBINARY_VERSION "2.0.5-dev"
 
 /* Macros */
 


### PR DESCRIPTION
(e.g. for pecl install)

`cc --version` won't output the substring gcc, even if gcc implements
cc. Autoconf sets the environment variables "$GCC" and "$ICC", however.

Check for clang first because it seems to imitate gcc