### PR TITLE
optimize the igbinary serializer/unserializer for performance

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+2.0.5 2017-??-??
+========
+* Slightly improve performance when unserializing objects.
+
 2.0.4 2017-04-14
 ========
 * Fixes bug #129: Should not call __wakeup() on data which was created by Serializable::unserialize()

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 2.0.5 2017-??-??
 ========
 * Slightly improve performance when unserializing objects.
+* Update unserialization of integer object keys for php 7.2: Make those keys accessible when unserializing.
 
 2.0.4 2017-04-14
 ========

--- a/benchmark/bench.php
+++ b/benchmark/bench.php
@@ -54,7 +54,7 @@ class Bench {
 
 	public function writeHeader() {
 		$header = implode("\t", array(
-			'name', 'start time', 'iterations', 'duration', 'rusage',
+			'name', 'start time', 'iterations', 'duration', 'rusage', 'current memory'
 		));
 		echo $header, "\n";
 		$this->headerWritten = true;
@@ -69,13 +69,13 @@ class Bench {
 			$this->writeHeader();
 		}
 
-		printf("%s\t%.6f\t%d\t%.8f\t%.6f\n",
+		printf("%s\t%.6f\t%d\t%.8f\t%.6f\t%dKB\n",
 			$this->name,
 			$this->startTime,
 			$this->iterations,
 			$this->stopTime - $this->startTime,
-			$this->stopUsage - $this->startUsage);
+			$this->stopUsage - $this->startUsage,
+			memory_get_usage() / 1024
+		);
 	}
 }
-
-

--- a/benchmark/unserialize-arrayarray.php
+++ b/benchmark/unserialize-arrayarray.php
@@ -1,0 +1,28 @@
+<?php
+
+// Description: Unserialize large array of arrays
+
+require_once 'bench.php';
+
+$b = new Bench('serialize-string-array');
+
+srand(13333);
+$data = [];
+for ($i = 0; $i < 1000; $i++) {
+    $part = [];
+    for ($j = 0; $j < rand() % 20; $j++) {
+        $part[] = rand() % 300;
+    }
+    $data[] = $part;
+}
+$ser = igbinary_serialize($data);
+
+for ($i = 0; $i < 40; $i++) {
+	$b->start();
+	for ($j = 0; $j < 500; $j++) {
+		$array = igbinary_unserialize($ser);
+	}
+	$b->stop($j);
+	$b->write();
+    unset($array);
+}

--- a/benchmark/unserialize-objectarray.totalmem.php
+++ b/benchmark/unserialize-objectarray.totalmem.php
@@ -1,0 +1,32 @@
+<?php
+
+// Description: Unserialize object array
+
+require_once 'bench.php';
+
+$b = new Bench('unserialize-object-array');
+
+class Obj {
+	private $foo = 10;
+	public $bar = "test";
+	public $i;
+}
+
+$array = array();
+for ($i = 0; $i < 1000; $i++) {
+	$o = new Obj();
+	$o->i = $i;
+
+	$array[] = $o;
+}
+$ser = igbinary_serialize($array);
+
+for ($i = 0; $i < 40; $i++) {
+	$b->start();
+	$arrays = [];
+	for ($j = 0; $j < 200; $j++) {
+		$arrays[] = igbinary_unserialize($ser);
+	}
+	$b->stop($j);
+	$b->write();
+}

--- a/benchmark/unserialize-stringarray.b.php
+++ b/benchmark/unserialize-stringarray.b.php
@@ -6,7 +6,7 @@ require_once 'bench.php';
 
 $b = new Bench('serialize-string-array');
 
-$ser = igbinary_serialize(unserialize(file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'l10n-en.ser')));
+$ser = igbinary_serialize(unserialize(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'l10n-en.ser')));
 
 for ($i = 0; $i < 40; $i++) {
 	$b->start();

--- a/src/php5/igbinary.c
+++ b/src/php5/igbinary.c
@@ -2058,7 +2058,19 @@ inline static int igbinary_unserialize_array(struct igbinary_unserialize_data *i
 				var_push_dtor(var_hash, old_v);
 			}
 */
-			zend_hash_index_update(h, key_index, &v, sizeof(v), NULL);
+			/* No point in the below code to convert by string, PHP 5 can access object number properties only by number. */
+			/*if (UNEXPECTED(object)) {
+				char id[32], *p;
+				int len;
+				p = smart_str_print_long(id + sizeof(id) - 1, (long) key_index);
+				len = id + sizeof(id) - 1 - p;
+				if (zend_symtable_find(h, key, key_len + 1, (void **)&old_v) == SUCCESS) {
+					var_push_dtor(var_hash, old_v);
+				}
+				zend_symtable_update(h, p, len + 1, &v, sizeof(v), NULL);
+			} else { */
+				zend_hash_index_update(h, key_index, &v, sizeof(v), NULL);
+			/* } */
 		}
 	}
 

--- a/src/php7/hash_si_ptr.c
+++ b/src/php7/hash_si_ptr.c
@@ -73,8 +73,6 @@ int hash_si_ptr_init(struct hash_si_ptr *h, size_t size) {
 /* }}} */
 /* {{{ hash_si_ptr_deinit */
 void hash_si_ptr_deinit(struct hash_si_ptr *h) {
-	size_t i;
-
 	free(h->data);
 	h->data = NULL;
 

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2187,13 +2187,11 @@ inline static int igbinary_unserialize_array(struct igbinary_unserialize_data *i
 		/* Use NULL because inserting UNDEF into array does not add a new element */
 		ZVAL_NULL(&v);
 		if (key_str != NULL) {
-			zend_hash_update(h, key_str, &v);
+			vp = zend_hash_update(h, key_str, &v);
 
-			vp = zend_hash_find(h, key_str);
 			zend_string_release(key_str);
 		} else {
-			zend_hash_index_update(h, key_index, &v);
-			vp = zend_hash_index_find(h, key_index);
+			vp = zend_hash_index_update(h, key_index, &v);
 		}
 
 		ZEND_ASSERT(vp != NULL);

--- a/tests/igbinary_012.phpt
+++ b/tests/igbinary_012.phpt
@@ -2,12 +2,12 @@
 Object test
 --SKIPIF--
 --FILE--
-<?php 
+<?php
 if(!extension_loaded('igbinary')) {
 	dl('igbinary.' . PHP_SHLIB_SUFFIX);
 }
 
-function test($type, $variable, $test) {
+function test($type, $variable) {
 	$serialized = igbinary_serialize($variable);
 	$unserialized = igbinary_unserialize($serialized);
 //	$serialized = serialize($variable);
@@ -16,7 +16,7 @@ function test($type, $variable, $test) {
 	echo $type, "\n";
 	echo substr(bin2hex($serialized), 8), "\n";
 //	echo $serialized, "\n";
-	echo $test || $unserialized == $variable ? 'OK' : 'ERROR';
+	echo $unserialized == $variable ? 'OK' : 'ERROR';
 	echo "\n";
 }
 
@@ -35,7 +35,7 @@ class Obj {
 $o = new Obj(1, 2, 3);
 
 
-test('object', $o, false);
+test('object', $o);
 
 /*
  * you can add regression tests for your extension here

--- a/tests/igbinary_030.phpt
+++ b/tests/igbinary_030.phpt
@@ -5,8 +5,9 @@ Unserialize invalid data
 if(!extension_loaded('igbinary')) {
 	echo "skip no igbinary";
 }
+?>
 --FILE--
-<?php 
+<?php
 
 $datas = array(
 	87817,
@@ -48,5 +49,23 @@ foreach ($datas as $data) {
 		var_dump($data);
 	}
 }
-
+?>
 --EXPECT--
+padded should get original
+object(stdClass)#2 (3) {
+  ["0"]=>
+  int(1)
+  ["1"]=>
+  int(2)
+  ["2"]=>
+  int(3)
+}
+vs.
+object(stdClass)#1 (3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}

--- a/tests/igbinary_030_php7.phpt
+++ b/tests/igbinary_030_php7.phpt
@@ -1,12 +1,12 @@
 --TEST--
-Unserialize invalid data (PHP 5)
+Unserialize invalid data
 --SKIPIF--
 <?php
 if(!extension_loaded('igbinary')) {
 	echo "skip no igbinary";
 }
-if (PHP_VERSION_ID >= 70000) {
-    echo "Skip php 5.6 or older required\n";
+if (PHP_VERSION_ID >= 70200 || PHP_VERSION_ID < 70000) {
+    echo "Skip php 7.1 or 7.0 required\n";
 }
 ?>
 --FILE--
@@ -59,12 +59,20 @@ foreach ($datas as $data) {
 ?>
 --EXPECT--
 padded should get original
-object(stdClass)#11 (1) {
-  [1]=>
-  string(6) "manual"
+object(stdClass)#3 (3) {
+  ["0"]=>
+  int(1)
+  ["1"]=>
+  int(2)
+  ["2"]=>
+  int(3)
 }
 vs.
-object(stdClass)#1 (1) {
-  ["1"]=>
-  string(6) "manual"
+object(stdClass)#2 (3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
 }

--- a/tests/igbinary_030_php72.phpt
+++ b/tests/igbinary_030_php72.phpt
@@ -1,12 +1,12 @@
 --TEST--
-Unserialize invalid data (PHP 5)
+Unserialize invalid data (php 7.2+)
 --SKIPIF--
 <?php
-if(!extension_loaded('igbinary')) {
+if (!extension_loaded('igbinary')) {
 	echo "skip no igbinary";
 }
-if (PHP_VERSION_ID >= 70000) {
-    echo "Skip php 5.6 or older required\n";
+if (PHP_VERSION_ID < 70200) {
+    echo "Skip php 7.2+ required\n";
 }
 ?>
 --FILE--
@@ -14,7 +14,6 @@ if (PHP_VERSION_ID >= 70000) {
 
 $o = new stdClass();
 $o->{"1"} = "manual";
-
 $datas = array(
 	87817,
 	-1,
@@ -58,13 +57,3 @@ foreach ($datas as $data) {
 }
 ?>
 --EXPECT--
-padded should get original
-object(stdClass)#11 (1) {
-  [1]=>
-  string(6) "manual"
-}
-vs.
-object(stdClass)#1 (1) {
-  ["1"]=>
-  string(6) "manual"
-}

--- a/tests/igbinary_046.phpt
+++ b/tests/igbinary_046.phpt
@@ -13,11 +13,13 @@ $a[2] = &$a[1];
 $a[3] = &$a[2];
 
 $ig_ser = igbinary_serialize($a);
+echo bin2hex($ig_ser) . "\n";
 $ig = igbinary_unserialize($ig_ser);
 $f = &$ig[3];
 $f = 'V';
 var_dump($ig);
 --EXPECT--
+000000021404060025110141060125010106022501010603250101
 array(4) {
   [0]=>
   &string(1) "V"

--- a/tests/igbinary_063.phpt
+++ b/tests/igbinary_063.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Accessing unserialized numbers.
+--SKIPIF--
+<?php
+if(!extension_loaded('igbinary')) {
+    echo "skip no igbinary";
+}
+if (PHP_VERSION_ID >= 70000) {
+    echo "Skip php 5.6 or lower required";
+}
+?>
+--FILE--
+<?php
+
+$data = (object)array(1,2,3, -1 => 'x', 1234 => 33);
+var_dump($data);
+$x = "1";
+$y = 1;
+$z = "1234";
+$w = 1234;
+var_dump(isset($data->{$x}) ? $data->{$x} : "unset");
+error_reporting(0);
+$str = serialize($data);
+
+$unserialized = unserialize($str);
+var_dump($unserialized);
+var_dump(isset($unserialized->{$x}) ? $unserialized->{$x} : "unset str");
+var_dump(isset($unserialized->{$y}) ? $unserialized->{$y} : "unset int");
+var_dump(isset($unserialized->{$z}) ? $unserialized->{$z} : "unset str 1234");
+var_dump(isset($unserialized->{$w}) ? $unserialized->{$w} : "unset int 1234");
+var_dump(isset($unserialized->{-1}) ? $unserialized->{-1} : "unset int -1");
+?>
+--EXPECTF--
+object(stdClass)#%d (5) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [-1]=>
+  string(1) "x"
+  [1234]=>
+  int(33)
+}
+string(5) "unset"
+object(stdClass)#%d (5) {
+  ["0"]=>
+  int(1)
+  ["1"]=>
+  int(2)
+  ["2"]=>
+  int(3)
+  ["-1"]=>
+  string(1) "x"
+  ["1234"]=>
+  int(33)
+}
+int(2)
+int(2)
+int(33)
+int(33)
+string(1) "x"

--- a/tests/igbinary_063_php7.phpt
+++ b/tests/igbinary_063_php7.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Accessing unserialized numbers.
+--SKIPIF--
+<?php
+if (!extension_loaded('igbinary')) {
+    echo "skip no igbinary";
+}
+if (PHP_VERSION_ID >= 70200 || PHP_VERSION_ID < 70000) {
+    echo "Skip php 7.1 or 7.0 required";
+}
+?>
+--FILE--
+<?php
+
+$data = (object)array(1,2,3, -1 => 'x', 1234 => 33);
+var_dump($data);
+$x = "1";
+$y = 1;
+$z = "1234";
+$w = 1234;
+var_dump(isset($data->{$x}) ? $data->{$x} : "unset");
+error_reporting(0);
+$str = igbinary_serialize($data);
+
+$unserialized = igbinary_unserialize($str);
+var_dump($unserialized);
+var_dump(isset($unserialized->{$x}) ? $unserialized->{$x} : "unset str");
+var_dump(isset($unserialized->{$y}) ? $unserialized->{$y} : "unset int");
+var_dump(isset($unserialized->{$z}) ? $unserialized->{$z} : "unset str 1234");
+var_dump(isset($unserialized->{$w}) ? $unserialized->{$w} : "unset int 1234");
+var_dump(isset($unserialized->{-1}) ? $unserialized->{-1} : "unset int -1");
+?>
+--EXPECT--
+object(stdClass)#1 (5) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [-1]=>
+  string(1) "x"
+  [1234]=>
+  int(33)
+}
+string(5) "unset"
+object(stdClass)#2 (5) {
+  ["0"]=>
+  int(1)
+  ["1"]=>
+  int(2)
+  ["2"]=>
+  int(3)
+  ["-1"]=>
+  string(1) "x"
+  ["1234"]=>
+  int(33)
+}
+int(2)
+int(2)
+int(33)
+int(33)
+string(1) "x"

--- a/tests/igbinary_063_php72.phpt
+++ b/tests/igbinary_063_php72.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Accessing unserialized numbers.
+--SKIPIF--
+<?php
+if(!extension_loaded('igbinary')) {
+	echo "skip no igbinary";
+}
+if (PHP_VERSION_ID < 70200) {
+    echo "Skip php 7.2+ required";
+}
+?>
+--FILE--
+<?php
+
+$data = (object)array(1,2,3, -1 => 'x', 1234 => 33);
+var_dump($data);
+$x = "1";
+$y = 1;
+$z = "1234";
+$w = 1234;
+var_dump(isset($data->{$x}) ? $data->{$x} : "unset");
+error_reporting(0);
+$str = igbinary_serialize($data);
+
+$unserialized = igbinary_unserialize($str);
+var_dump($unserialized);
+var_dump(isset($unserialized->{$x}) ? $unserialized->{$x} : "unset str");
+var_dump(isset($unserialized->{$y}) ? $unserialized->{$y} : "unset int");
+var_dump(isset($unserialized->{$z}) ? $unserialized->{$z} : "unset str 1234");
+var_dump(isset($unserialized->{$w}) ? $unserialized->{$w} : "unset int 1234");
+var_dump(isset($unserialized->{-1}) ? $unserialized->{-1} : "unset int -1");
+?>
+--EXPECT--
+object(stdClass)#1 (5) {
+  ["0"]=>
+  int(1)
+  ["1"]=>
+  int(2)
+  ["2"]=>
+  int(3)
+  ["-1"]=>
+  string(1) "x"
+  ["1234"]=>
+  int(33)
+}
+int(2)
+object(stdClass)#2 (5) {
+  ["0"]=>
+  int(1)
+  ["1"]=>
+  int(2)
+  ["2"]=>
+  int(3)
+  ["-1"]=>
+  string(1) "x"
+  ["1234"]=>
+  int(33)
+}
+int(2)
+int(2)
+int(33)
+int(33)
+string(1) "x"


### PR DESCRIPTION
and fix edge case in support of php 7.2 
- Unserialize integer object property keys as accessible string representations.
- and update test expectation for php 7.2-like field unserialization

Change to buffer_ptr

Speed up array unserialization

Support objects with numeric literals in a consistent way.

var_dump has different output depending on the php version

Optimize memory: don't create hash table if properties already exist
- Faster property setting, set and retrieve pointer to zval at the same time.

Add other benchmarking scripts
- benchmark/unserialize-objectarray.b.php improved from 0.125s to 0.112 seconds
