### PR TITLE
Use empty string for serializing empty session in all php versions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@
 * Update unserialization of integer object keys for php 7.2: Make those keys accessible when unserializing.
 * Properly pick up presence of gcc for default compiler flags (`cc --version` doesn't contain gcc).
   Add -O2 to default gcc compiler flags.
+* Use empty string for serializing empty $_SESSION array, similar to "session.serialize_handler=php".
+  Older igbinary releases already unserialize the empty string to the empty array.
 
 2.0.4 2017-04-14
 ========

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -598,9 +598,17 @@ PHP_FUNCTION(igbinary_serialize) {
 /* {{{ Serializer encode function */
 PS_SERIALIZER_ENCODE_FUNC(igbinary)
 {
+	zval* session_vars;
 	zend_string *result;
 	struct igbinary_serialize_data igsd;
 
+	session_vars = &(PS(http_session_vars));
+	if (Z_ISREF_P(session_vars)) {
+		session_vars = Z_REFVAL_P(session_vars);
+	}
+	if (Z_TYPE_P(session_vars) == IS_ARRAY && zend_hash_num_elements(Z_ARRVAL_P(session_vars)) == 0) {
+		return ZSTR_EMPTY_ALLOC();
+	}
 	if (igbinary_serialize_data_init(&igsd, false, NULL)) {
 		zend_error(E_WARNING, "igbinary_serialize: cannot init igsd");
 		return ZSTR_EMPTY_ALLOC();
@@ -612,7 +620,7 @@ PS_SERIALIZER_ENCODE_FUNC(igbinary)
 		return ZSTR_EMPTY_ALLOC();
 	}
 
-	if (igbinary_serialize_array(&igsd, &(PS(http_session_vars)), false, false) != 0) {
+	if (igbinary_serialize_array(&igsd, session_vars, false, false) != 0) {
 		igbinary_serialize_data_deinit(&igsd, 1);
 		zend_error(E_WARNING, "igbinary_serialize: cannot serialize session variables");
 		return ZSTR_EMPTY_ALLOC();

--- a/tests/igbinary_015c.phpt
+++ b/tests/igbinary_015c.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Check for serialization handler
+--SKIPIF--
+<?php
+if (!extension_loaded('session')) {
+	exit('skip session extension not loaded');
+}
+
+ob_start();
+phpinfo(INFO_MODULES);
+$str = ob_get_clean();
+
+$array = explode("\n", $str);
+$array = preg_grep('/^igbinary session support.*yes/', $array);
+if (!$array) {
+	exit('skip igbinary session handler not available');
+}
+?>
+--FILE--
+<?php
+
+$output = '';
+
+function open($path, $name) {
+	return true;
+}
+
+function close() {
+	return true;
+}
+
+function read($id) {
+    global $output;
+    $output .= "read($id)\n";
+	return '';
+}
+
+function write($id, $data) {
+	global $output;
+	$output .= "write($id): data:(" . bin2hex($data) . ")\n";
+	return true;
+}
+
+function destroy($id) {
+	return true;
+}
+
+function gc($time) {
+	return true;
+}
+
+ini_set('session.serialize_handler', 'igbinary');
+
+session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
+session_id('abcdef10231512dfaz_12311');
+
+session_start();
+
+// save an empty session
+session_write_close();
+
+echo $output;
+
+/*
+ * you can add regression tests for your extension here
+ *
+ * the output of your test code has to be equal to the
+ * text in the --EXPECT-- section below for the tests
+ * to pass, differences between the output and the
+ * expected text are interpreted as failure
+ *
+ * see php5/README.TESTING for further information on
+ * writing regression tests
+ */
+?>
+--EXPECT--
+read(abcdef10231512dfaz_12311)
+write(abcdef10231512dfaz_12311): data:()


### PR DESCRIPTION
This saves 6 bytes per session.
Previously, igbinary would serialize as "\x00\x00\x00\x02\x14\x00".
The "php" session handler does the same thing.

Fixes #146