### PR TITLE
Speed up serializing strings, re-use hashes of struct zend_string

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 2.0.5 2017-?-? (dev)
 ========
-* Slightly improve performance when unserializing objects.
+* Improve performance when unserializing objects/arrays and serializing objects/arrays/strings in php 7.
 * Update unserialization of integer object keys for php 7.2: Make those keys accessible when unserializing.
 * Properly pick up presence of gcc for default compiler flags (`cc --version` doesn't contain gcc).
   Add -O2 to default gcc compiler flags.

--- a/src/php7/hash.h
+++ b/src/php7/hash.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <stddef.h>
+#include "zend_types.h"
 
 /** Key/value pair of hash_si.
  * @author Oleg Grenrus <oleg.grenrus@dynamoid.com>
@@ -94,12 +95,11 @@ int hash_si_find (struct hash_si *h, const char *key, size_t key_len, uint32_t *
 /** Finds value from hash_si.
  * Value returned thru value param.
  * @param h Pointer to hash_si struct.
- * @param key Pointer to key.
- * @param key_len Key length.
+ * @param key zend_string with key
  * @param[out] value Found value.
  * @return 0 if found, 1 if not.
  */
-struct hash_si_result hash_si_find_or_insert(struct hash_si *h, const char *key, size_t key_len, uint32_t value);
+struct hash_si_result hash_si_find_or_insert(struct hash_si *h, zend_string *key, uint32_t value);
 
 /** Remove value from hash_si.
  * Removed value is available thru value param.

--- a/src/php7/hash_si.c
+++ b/src/php7/hash_si.c
@@ -88,7 +88,7 @@ inline static size_t _hash_si_find(const struct hash_si *h, const char *key, con
 	while (size > 0 &&
 		h->data[hv].key != NULL &&
 		(h->data[hv].key_hash != key_hash || h->data[hv].key_len != key_len || UNEXPECTED(memcmp(h->data[hv].key, key, key_len) != 0))) {
-		/* linear prob */
+		/* linear probing */
 		hv = (hv + 1) & mask;
 		size--;
 	}
@@ -171,15 +171,18 @@ int hash_si_find(struct hash_si *h, const char *key, size_t key_len, uint32_t *v
 */
 /* }}} */
 /* {{{ hash_si_find_or_insert */
-struct hash_si_result hash_si_find_or_insert(struct hash_si *h, const char *key, size_t key_len, uint32_t value) {
+struct hash_si_result hash_si_find_or_insert(struct hash_si *h, zend_string *key_zstr, uint32_t value) {
 	uint32_t hv;
 	uint32_t key_hash;
 	struct hash_si_result result;
 	struct hash_si_pair *pair;
+	const char* key;
+	size_t key_len;
 
-	assert(h != NULL);
-
-	key_hash = zend_inline_hash_func(key, key_len);
+	ZEND_ASSERT(h != NULL);
+	key = ZSTR_VAL(key_zstr);
+	key_len = ZSTR_LEN(key_zstr);
+	key_hash = ZSTR_HASH(key_zstr);  // TODO: convert to ZSTR_HASH
 	hv = _hash_si_find(h, key, key_len, key_hash);
 	pair = &h->data[hv];
 


### PR DESCRIPTION
with CFLAGS=-O3

serialize-objectarray sped up from 0.239 to 0.215 seconds
serialize-stringarray sped up from 0.317 to 0.225 seconds