### PR TITLE
Improve hash_si performance for serializing strings, fix php 5 test failure.

### DIFF
--- a/src/php5/igbinary.c
+++ b/src/php5/igbinary.c
@@ -2082,19 +2082,19 @@ inline static int igbinary_unserialize_array(struct igbinary_unserialize_data *i
 				var_push_dtor(var_hash, old_v);
 			}
 */
-			/* No point in the below code to convert by string, PHP 5 can access object number properties only by number. */
-			/*if (UNEXPECTED(object)) {
+			/* PHP 5 can access object number properties only by string. */
+			if (UNEXPECTED(object)) {
 				char id[32], *p;
 				int len;
 				p = smart_str_print_long(id + sizeof(id) - 1, (long) key_index);
 				len = id + sizeof(id) - 1 - p;
-				if (zend_symtable_find(h, key, key_len + 1, (void **)&old_v) == SUCCESS) {
+				/*if (zend_symtable_find(h, key, key_len + 1, (void **)&old_v) == SUCCESS) {
 					var_push_dtor(var_hash, old_v);
-				}
-				zend_symtable_update(h, p, len + 1, &v, sizeof(v), NULL);
-			} else { */
+				} */
+				zend_hash_update(h, p, len + 1, &v, sizeof(v), NULL); /* See process_nested_data from ext/standard/var_unserializer.re */
+			} else {
 				zend_hash_index_update(h, key_index, &v, sizeof(v), NULL);
-			/* } */
+			}
 		}
 	}
 

--- a/src/php7/hash.h
+++ b/src/php7/hash.h
@@ -27,10 +27,9 @@
  */
 struct hash_si_pair
 {
-	char *key;			/**< Pointer to key. */
-	size_t key_len;		/**< Key length. */
-	uint32_t key_hash;  /**< Key hash. */
-	uint32_t value;		/**< Value. */
+	zend_string* key_zstr;  /* Contains key, key length, and key hash */
+	uint32_t key_hash;		/**< Copy of ZSTR_H(key_zstr). Avoid dereferencing key_zstr if hashes are different. */
+	uint32_t value;		    /**< Value. */
 };
 
 enum hash_si_code {
@@ -46,12 +45,12 @@ struct hash_si_result
 };
 
 /** Hash-array.
- * Like c++ map<char *, int32_t>.
- * Current implementation uses linear probing.
+ * Like c++ unordered_map<char *, int32_t>.
+ * Current implementation uses linear probing (with interval 1, 3, 5, or 7).
  * @author Oleg Grenrus <oleg.grenrus@dynamoid.com>
  */
 struct hash_si {
-	size_t size; 					/**< Allocated size of array. */
+	size_t mask; 					/**< Bitmask for the array. size == mask+1 */
 	size_t used;					/**< Used size of array. */
 	struct hash_si_pair *data;		/**< Pointer to array or pairs of data. */
 };

--- a/tests/igbinary_030.phpt
+++ b/tests/igbinary_030.phpt
@@ -25,7 +25,7 @@ $datas = array(
 	"dakjdh98389\000",
 	null,
 	(object)array(1,2,3),
-    $o,
+    $o,  // some weirdness unserializing with zend_hash_update on strings that are integers.
 );
 
 error_reporting(0);
@@ -58,6 +58,24 @@ foreach ($datas as $data) {
 }
 ?>
 --EXPECT--
+padded should get original
+object(stdClass)#8 (3) {
+  ["0"]=>
+  int(1)
+  ["1"]=>
+  int(2)
+  ["2"]=>
+  int(3)
+}
+vs.
+object(stdClass)#2 (3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
 padded should get original
 object(stdClass)#11 (1) {
   [1]=>

--- a/tests/igbinary_063.phpt
+++ b/tests/igbinary_063.phpt
@@ -20,9 +20,9 @@ $z = "1234";
 $w = 1234;
 var_dump(isset($data->{$x}) ? $data->{$x} : "unset");
 error_reporting(0);
-$str = serialize($data);
+$str = igbinary_serialize($data);
 
-$unserialized = unserialize($str);
+$unserialized = igbinary_unserialize($str);
 var_dump($unserialized);
 var_dump(isset($unserialized->{$x}) ? $unserialized->{$x} : "unset str");
 var_dump(isset($unserialized->{$y}) ? $unserialized->{$y} : "unset int");

--- a/tests/igbinary_064.phpt
+++ b/tests/igbinary_064.phpt
@@ -1,0 +1,138 @@
+--TEST--
+Works when there are hash collisions in strings when serializing.
+--SKIPIF--
+<?php
+if(!extension_loaded('igbinary')) {
+    echo "skip no igbinary";
+}
+?>
+--FILE--
+<?php
+
+class Fy{
+    public $EzFy = 2;
+    public function __construct($x) {
+        $this->x = $x;
+    }
+}
+class Ez {
+    public $FyEz = 'EzEz';
+}
+
+class G8 {
+    public $FyG8;
+}
+
+$data = [new Fy('G8G8'), new Fy('EzG8'), new Ez(), new G8(), new Ez(), 'G8' => new G8(), 'F8Ez' => new G8(), [new G8()]];
+var_dump($data);
+echo "\n";
+$str = igbinary_serialize($data);
+echo bin2hex($str) . "\n";
+$unserialized = igbinary_unserialize($str);
+var_dump($unserialized);
+echo "\n";
+var_export(serialize($data) === serialize($unserialized));
+?>
+--EXPECT--
+array(8) {
+  [0]=>
+  object(Fy)#1 (2) {
+    ["EzFy"]=>
+    int(2)
+    ["x"]=>
+    string(4) "G8G8"
+  }
+  [1]=>
+  object(Fy)#2 (2) {
+    ["EzFy"]=>
+    int(2)
+    ["x"]=>
+    string(4) "EzG8"
+  }
+  [2]=>
+  object(Ez)#3 (1) {
+    ["FyEz"]=>
+    string(4) "EzEz"
+  }
+  [3]=>
+  object(G8)#4 (1) {
+    ["FyG8"]=>
+    NULL
+  }
+  [4]=>
+  object(Ez)#5 (1) {
+    ["FyEz"]=>
+    string(4) "EzEz"
+  }
+  ["G8"]=>
+  object(G8)#6 (1) {
+    ["FyG8"]=>
+    NULL
+  }
+  ["F8Ez"]=>
+  object(G8)#7 (1) {
+    ["FyG8"]=>
+    NULL
+  }
+  [5]=>
+  array(1) {
+    [0]=>
+    object(G8)#8 (1) {
+      ["FyG8"]=>
+      NULL
+    }
+  }
+}
+
+00000002140806001702467914021104457a4679060211017811044738473806011a0014020e0106020e021104457a473806021702457a140111044679457a1104457a457a06031702473814011104467947380006041a0514010e060e070e081a0814010e090011044638457a1a0814010e09000605140106001a0814010e0900
+array(8) {
+  [0]=>
+  object(Fy)#9 (2) {
+    ["EzFy"]=>
+    int(2)
+    ["x"]=>
+    string(4) "G8G8"
+  }
+  [1]=>
+  object(Fy)#10 (2) {
+    ["EzFy"]=>
+    int(2)
+    ["x"]=>
+    string(4) "EzG8"
+  }
+  [2]=>
+  object(Ez)#11 (1) {
+    ["FyEz"]=>
+    string(4) "EzEz"
+  }
+  [3]=>
+  object(G8)#12 (1) {
+    ["FyG8"]=>
+    NULL
+  }
+  [4]=>
+  object(Ez)#13 (1) {
+    ["FyEz"]=>
+    string(4) "EzEz"
+  }
+  ["G8"]=>
+  object(G8)#14 (1) {
+    ["FyG8"]=>
+    NULL
+  }
+  ["F8Ez"]=>
+  object(G8)#15 (1) {
+    ["FyG8"]=>
+    NULL
+  }
+  [5]=>
+  array(1) {
+    [0]=>
+    object(G8)#16 (1) {
+      ["FyG8"]=>
+      NULL
+    }
+  }
+}
+
+true


### PR DESCRIPTION
serialize_object_array sped up from 2.27 to 1.85 seconds.
Minor improvements of serialize_string_array (0.20s to 0.18s)

Fix typo in earlier test.