### PR TITLE
Create 2.0.5RC1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-2.0.5 2017-?-? (dev)
+2.0.5RC1 2017-10-15
 ========
 * Improve performance when unserializing objects/arrays and serializing objects/arrays/strings in php 5/7.
 * Update unserialization of integer object keys for php 7.2: Make those keys accessible when unserializing.

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -34,8 +34,8 @@ PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
 if [ "$PHP_CUSTOM_NORMAL_VERSION" != "7.2.0" ] ; then
     curl --verbose https://secure.php.net/distributions/$PHP_TAR_FILE -o $PHP_TAR_FILE
 else
-    curl --verbose https://downloads.php.net/~pollita/php-7.2.0RC2.tar.bz2 -o $PHP_TAR_FILE
-    PHP_FOLDER="php-7.2.0RC2"
+    curl --verbose https://downloads.php.net/~remi/php-7.2.0RC4.tar.bz2 -o $PHP_TAR_FILE
+    PHP_FOLDER="php-7.2.0RC4"
 fi
 
 tar xjf $PHP_TAR_FILE

--- a/config.m4
+++ b/config.m4
@@ -67,7 +67,7 @@ if test "$PHP_IGBINARY" != "no"; then
   elif test "$GCC" = yes; then
     AC_MSG_RESULT(gcc)
     if test -z "`echo $CFLAGS | grep -- '-O[0123]'`"; then
-      PHP_IGBINARY_CFLAGS="$CFLAGS -O2 -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -Winline -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
+      PHP_IGBINARY_CFLAGS="$CFLAGS -O2 -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
     fi
   elif test "$ICC" = yes; then
     AC_MSG_RESULT(icc)

--- a/package.xml
+++ b/package.xml
@@ -38,7 +38,7 @@
   <api>1.1.1</api>
  </version>
  <stability>
-  <release>stable</release>
+  <release>beta</release>
   <api>stable</api>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
@@ -177,6 +177,10 @@
     <release>2.0.5RC1</release>
     <api>1.1.1</api>
    </version>
+   <stability>
+    <release>beta</release>
+    <api>stable</api>
+   </stability>
    <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
    <notes>
 * Improve performance when unserializing objects/arrays and serializing objects/arrays/strings in php 5/7.
@@ -194,6 +198,10 @@
     <release>2.0.4</release>
     <api>1.1.1</api>
    </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
    <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
    <notes>
 * Fixes bug #129: Should not call __wakeup() on data which was created by Serializable::unserialize()
@@ -206,6 +214,10 @@
     <release>2.0.3</release>
     <api>1.1.1</api>
    </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
    <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
    <notes>
 - Fixes bug #126: Fatal error: "igbinary_serialize_zval: zval has unknown type 0" (IS_UNDEF)
@@ -220,6 +232,10 @@
     <release>2.0.2</release>
     <api>1.1.1</api>
    </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
    <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
    <notes>
 - Compatible with PHP 5.2 - 7.1

--- a/package.xml
+++ b/package.xml
@@ -31,10 +31,10 @@
   <email>tysonandre775@hotmail.com</email>
   <active>yes</active>
  </lead>
- <date>2017-03-31</date>
+ <date>2017-10-15</date>
  <time>16:00:00</time>
  <version>
-  <release>2.0.5</release>
+  <release>2.0.5RC1</release>
   <api>1.1.1</api>
  </version>
  <stability>
@@ -94,6 +94,7 @@
     <file name="igbinary_014.phpt" role="test" />
     <file name="igbinary_015.phpt" role="test" />
     <file name="igbinary_015b.phpt" role="test" />
+    <file name="igbinary_015c.phpt" role="test" />
     <file name="igbinary_016.phpt" role="test" />
     <file name="igbinary_017.phpt" role="test" />
     <file name="igbinary_018.phpt" role="test" />
@@ -109,6 +110,8 @@
     <file name="igbinary_027.phpt" role="test" />
     <file name="igbinary_028.phpt" role="test" />
     <file name="igbinary_029.phpt" role="test" />
+    <file name="igbinary_030_php72.phpt" role="test" />
+    <file name="igbinary_030_php7.phpt" role="test" />
     <file name="igbinary_030.phpt" role="test" />
     <file name="igbinary_031.phpt" role="test" />
     <file name="igbinary_032.phpt" role="test" />
@@ -144,6 +147,10 @@
     <file name="igbinary_060.phpt" role="test" />
     <file name="igbinary_061.phpt" role="test" />
     <file name="igbinary_062.phpt" role="test" />
+    <file name="igbinary_063_php72.phpt" role="test" />
+    <file name="igbinary_063_php7.phpt" role="test" />
+    <file name="igbinary_063.phpt" role="test" />
+    <file name="igbinary_064.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />
@@ -164,16 +171,20 @@
  <extsrcrelease />
  <changelog>
   <release>
-   <date>2017-10-11</date>
+   <date>2017-10-15</date>
    <time>16:00:00</time>
    <version>
-    <release>2.0.5-dev</release>
+    <release>2.0.5RC1</release>
     <api>1.1.1</api>
    </version>
    <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
    <notes>
+* Improve performance when unserializing objects/arrays and serializing objects/arrays/strings in php 5/7.
+* Update unserialization of integer object keys for php 7.2: Make those keys accessible when unserializing.
 * Properly pick up presence of gcc for default compiler flags (`cc --version` doesn't contain gcc).
   Add -O2 to default gcc compiler flags.
+* Use empty string for serializing empty $_SESSION array, similar to "session.serialize_handler=php".
+  Older igbinary releases already unserialize the empty string to the empty array.
    </notes>
   </release>
   <release>

--- a/src/php5/igbinary.h
+++ b/src/php5/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "2.0.5-dev"
+#define PHP_IGBINARY_VERSION "2.0.5RC1"
 
 /* Macros */
 #ifdef PHP_WIN32

--- a/src/php7/hash_si.c
+++ b/src/php7/hash_si.c
@@ -77,13 +77,14 @@ inline static struct hash_si_pair *_hash_si_find(const struct hash_si *h, const 
 	struct hash_si_pair *it;
 	const struct hash_si_pair *last_element;
 	uint32_t increment;
+	uint32_t elem_key_hash;
 
 	assert(h != NULL);
 
 	mask = h->mask;
 	it = &(h->data[key_hash & mask]);
 
-	const uint32_t elem_key_hash = it->key_hash;
+	elem_key_hash = it->key_hash;
 	if (elem_key_hash == 0) {
 		/* This slot is empty - PHP guarantees hashes are non-zero */
 		return it;
@@ -108,7 +109,7 @@ inline static struct hash_si_pair *_hash_si_find(const struct hash_si *h, const 
 			it -= (mask + 1);
 		}
 
-		const uint32_t elem_key_hash = it->key_hash;
+		elem_key_hash = it->key_hash;
 		if (elem_key_hash == 0) {
 			/* This slot is empty - PHP guarantees hashes are non-zero */
 			return it;

--- a/src/php7/hash_si.c
+++ b/src/php7/hash_si.c
@@ -56,7 +56,7 @@ void hash_si_deinit(struct hash_si *h) {
 
 	for (i = 0; i <= h->mask; i++) {
 		if (h->data[i].key_zstr != NULL) {
-			zend_string_delref(h->data[i].key_zstr);
+			zend_string_release(h->data[i].key_zstr);
 		}
 	}
 

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "2.0.5-dev"
+#define PHP_IGBINARY_VERSION "2.0.5RC1"
 
 /* Macros */
 

--- a/tests/igbinary_025b.phpt
+++ b/tests/igbinary_025b.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Object test, array of small objects with __sleep
+--SKIPIF--
+--FILE--
+<?php
+if(!extension_loaded('igbinary')) {
+	dl('igbinary.' . PHP_SHLIB_SUFFIX);
+}
+
+function test($type, $variable, $test) {
+	$serialized = igbinary_serialize($variable);
+	$unserialized = igbinary_unserialize($serialized);
+
+	var_dump($variable);
+	var_dump($unserialized);
+}
+
+class Obj {
+	private $c;
+
+	function __construct($c) {
+		$this->c = $c;
+	}
+
+	function __sleep() {
+		return array('c');
+	}
+}
+
+$obj = new Obj(4);
+
+test('array', $obj, true);
+
+?>
+--EXPECT--
+object(Obj)#1 (1) {
+  ["c":"Obj":private]=>
+  int(4)
+}
+object(Obj)#2 (1) {
+  ["c":"Obj":private]=>
+  int(4)
+}

--- a/tests/igbinary_064.phpt
+++ b/tests/igbinary_064.phpt
@@ -23,7 +23,7 @@ class G8 {
     public $FyG8;
 }
 
-$data = [new Fy('G8G8'), new Fy('EzG8'), new Ez(), new G8(), new Ez(), 'G8' => new G8(), 'F8Ez' => new G8(), [new G8()]];
+$data = array(new Fy('G8G8'), new Fy('EzG8'), new Ez(), new G8(), new Ez(), 'G8' => new G8(), 'F8Ez' => new G8(), array(new G8()));
 var_dump($data);
 echo "\n";
 $str = igbinary_serialize($data);


### PR DESCRIPTION
Add missing test files to package.xml
Fix warning about shadowing
use php 5.3 array syntax instead of shorthand php array syntax in test file.