### PR TITLE
Prevent IS_UNDEF warning for variable missing from __sleep() (Replace with a notice similar to php5's)

### DIFF
--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2556,7 +2556,7 @@ inline static int igbinary_unserialize_object(struct igbinary_unserialize_data *
 	}
 
 	{
-		struct igbinary_value_ref ref;
+		struct igbinary_value_ref ref = {0};
 		ref_n = igsd_append_ref(igsd, ref);
 		if (ref_n == SIZE_MAX) {
 			zend_string_release(class_name);

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -1334,6 +1334,11 @@ inline static int igbinary_serialize_array_sleep(struct igbinary_serialize_data 
 				if (Z_TYPE_P(v) == IS_INDIRECT) {
 					v = Z_INDIRECT_P(v);
 				}
+				if (UNEXPECTED(Z_TYPE_P(v) == IS_UNDEF)) {
+					php_error_docref(NULL, E_NOTICE, "\"%s\" returned as member variable from __sleep() but does not exist", Z_STRVAL_P(d));
+					igbinary_serialize_null(igsd);
+					continue;
+				}
 				if (igbinary_serialize_zval(igsd, v) != 0) {
 					return 1;
 				}
@@ -1384,6 +1389,12 @@ inline static int igbinary_serialize_array_sleep(struct igbinary_serialize_data 
 					}
 
 					zend_string_release(mangled_prop_name);
+
+					if (UNEXPECTED(Z_TYPE_P(v) == IS_UNDEF)) {
+						php_error_docref(NULL, E_NOTICE, "\"%s\" returned as member variable from __sleep() but does not exist", Z_STRVAL_P(d));
+						igbinary_serialize_null(igsd);
+						break;
+					}
 					if (igbinary_serialize_zval(igsd, v) != 0) {
 						return 1;
 					}
@@ -1676,8 +1687,8 @@ static int igbinary_serialize_zval(struct igbinary_serialize_data *igsd, zval *z
 		case IS_NULL:
 			return igbinary_serialize_null(igsd);
 		case IS_UNDEF:
-			// As of php 7.1.3, started seeing "zval has unknown type 0"
-			zend_error(E_WARNING, "igbinary_serialize_zval: zval has unexpected type IS_UNDEF(0)");
+			// https://github.com/igbinary/igbinary/issues/134
+			// TODO: In a new major version, could have a separate type for IS_UNDEF, which would unset the property in an object context?
 			return igbinary_serialize_null(igsd);
 		case IS_TRUE:
 			return igbinary_serialize_bool(igsd, 1);

--- a/tests/igbinary_065.phpt
+++ b/tests/igbinary_065.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Don't emit zval has unknown type 0 (IS_UNDEF)
+--FILE--
+<?php
+
+class MyClass {
+    public $kept = 2;
+    public $x;
+    protected $y;
+    private $z;
+    protected $set = 2;
+    private $priv = 2;
+    private $omitted = 'myVal';
+
+    public function __sleep() {
+        unset($this->x);
+        unset($this->y);
+        unset($this->z);
+        $this->set = 'setVal';
+        $this->priv = null;
+        $this->omitted = 'otherVal';
+
+        return ['kept', 'x', 'y', 'z', 'set', 'priv'];
+    }
+}
+error_reporting(E_ALL);
+// TODO: emit 'Notice: igbinary_serialize(): "x" returned as member variable from __sleep() but does not exist' instead.
+$serialized = igbinary_serialize(new MyClass());
+echo bin2hex($serialized) . "\n";
+var_export(igbinary_unserialize($serialized));
+echo "\n";
+?>
+--EXPECTF--
+Notice: igbinary_serialize(): "x" returned as member variable from __sleep() but does not exist in %s on line 25
+
+Notice: igbinary_serialize(): "y" returned as member variable from __sleep() but does not exist in %s on line 25
+
+Notice: igbinary_serialize(): "z" returned as member variable from __sleep() but does not exist in %s on line 25
+0000000217074d79436c617373140611046b6570740602110178001104002a007900110a004d79436c617373007a001106002a00736574110673657456616c110d004d79436c617373007072697600
+MyClass::__set_state(array(
+   'kept' => 2,
+   'x' => NULL,
+   'y' => NULL,
+   'z' => NULL,
+   'set' => 'setVal',
+   'priv' => NULL,
+   'omitted' => 'myVal',
+))

--- a/tests/igbinary_065_php5.phpt
+++ b/tests/igbinary_065_php5.phpt
@@ -2,8 +2,8 @@
 Don't emit zval has unknown type 0 (IS_UNDEF)
 --SKIPIF--
 <?php
-if (PHP_MAJOR_VERSION < 7) {
-	exit('skip a separate test case tests php5');
+if (PHP_MAJOR_VERSION > 5) {
+	exit('skip regression test for php 5 behavior');
 }
 ?>
 --FILE--
@@ -25,7 +25,7 @@ class MyClass {
         $this->set = 'setVal';
         $this->priv = null;
         $this->omitted = 'otherVal';
-
+		// TODO: php5 misbehaves - It can't find the property definition, so creates a *public* property for y and z
         return ['kept', 'x', 'y', 'z', 'set', 'priv'];
     }
 }
@@ -42,7 +42,7 @@ Notice: igbinary_serialize(): "x" returned as member variable from __sleep() but
 Notice: igbinary_serialize(): "y" returned as member variable from __sleep() but does not exist in %s on line 25
 
 Notice: igbinary_serialize(): "z" returned as member variable from __sleep() but does not exist in %s on line 25
-0000000217074d79436c617373140611046b6570740602110178001104002a007900110a004d79436c617373007a001106002a00736574110673657456616c110d004d79436c617373007072697600
+0000000217074d79436c617373140611046b6570740602110178001101790011017a001106002a00736574110673657456616c110d004d79436c617373007072697600
 MyClass::__set_state(array(
    'kept' => 2,
    'x' => NULL,
@@ -51,4 +51,6 @@ MyClass::__set_state(array(
    'set' => 'setVal',
    'priv' => NULL,
    'omitted' => 'myVal',
+   'y' => NULL,
+   'z' => NULL,
 ))


### PR DESCRIPTION
Fixes #134

This makes php7 emit a notice about __sleep returning member
variable that does not exist.