### PR TITLE
Windows: Allow session to not be enabled in configure

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -40,6 +40,6 @@ if (PHP_IGBINARY == "yes") {
   EXTENSION("igbinary", php_igbinary_src_files);
   configure_module_dirname = old_conf_dir;
   AC_DEFINE('HAVE_IGBINARY', 1, 'Have igbinary support', false);
-  ADD_EXTENSION_DEP('igbinary', 'session');
+  ADD_EXTENSION_DEP('igbinary', 'session', true);
   PHP_INSTALL_HEADERS('ext/igbinary', 'igbinary.h php_igbinary.h ' + subdir + '\\igbinary.h ' + subdir + '\\php_igbinary.h');
 }


### PR DESCRIPTION
The extension does not require session and can be compiled without it.
This change makes configure behave the same as it does for non-Windows
platforms (see https://github.com/igbinary/igbinary/blob/master/config.m4#L84).

Fixes #163 