### PR TITLE
Fixed compile failure on win32 in debug mode

### DIFF
--- a/src/php7/ig_win32.h
+++ b/src/php7/ig_win32.h
@@ -24,6 +24,9 @@ typedef bool _Bool;
 #  define true 1
 #  define __bool_true_false_are_defined 1
 # endif /* __MSC_VER */
+# ifdef _DEBUG
+#  include <crtdbg.h>
+# endif
 #endif /* PHP_WIN32 */
 
 #endif  /* _IG_WIN32_H */


### PR DESCRIPTION
Include crtdbg header when using `--enable-debug`

Without this patch, compilation fails with the following:
```
ext\igbinary\src\php7\igbinary.c(516): warning C4002: too many actual parameters for macro 'realloc'
ext\igbinary\src\php7\igbinary.c(516): error C2039: '_realloc_dbg': is not a member of 'igbinary_memory_manager'
c:\php-sdk\php\vc15\x64\php-src\ext\igbinary\src\php7\igbinary.h(46): note: see declaration of 'igbinary_memory_manager'
ext\igbinary\src\php7\igbinary.c(771): warning C4002: too many actual parameters for macro 'free'
ext\igbinary\src\php7\igbinary.c(771): error C2039: '_free_dbg': is not a member of 'igbinary_memory_manager'
c:\php-sdk\php\vc15\x64\php-src\ext\igbinary\src\php7\igbinary.h(46): note: see declaration of 'igbinary_memory_manager'
ext\igbinary\src\php7\igbinary.c(797): warning C4002: too many actual parameters for macro 'realloc'
ext\igbinary\src\php7\igbinary.c(797): error C2039: '_realloc_dbg': is not a member of 'igbinary_memory_manager'
c:\php-sdk\php\vc15\x64\php-src\ext\igbinary\src\php7\igbinary.h(46): note: see declaration of 'igbinary_memory_manager'
```

I don't know if this patch also needs to be applied to the `php5` branch.