### PR TITLE
Remove build flags that cause unavoidable warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ php:
 # For unsupported versions(5.4-5.5), run minimal tests to cover 32-bit, 64-bit, and clang
 # Exclude everything else.
 matrix:
+  allow_failures:
+  - php: master
   exclude:
   - php: 5.4
     env: CC=clang   CFLAGS="-g -O0"

--- a/config.m4
+++ b/config.m4
@@ -67,7 +67,7 @@ if test "$PHP_IGBINARY" != "no"; then
   elif test "$GCC" = yes; then
     AC_MSG_RESULT(gcc)
     if test -z "`echo $CFLAGS | grep -- '-O[0123]'`"; then
-      PHP_IGBINARY_CFLAGS="$CFLAGS -O2 -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes -Wcast-align -Wshadow -Wwrite-strings -Wswitch -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
+      PHP_IGBINARY_CFLAGS="$CFLAGS -O2 -Wall -Wpointer-arith -Wcast-align -Wwrite-strings -Wswitch -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
     fi
   elif test "$ICC" = yes; then
     AC_MSG_RESULT(icc)


### PR DESCRIPTION
Fixes #169

The code automatically generated by PHP, as well as headers outside
igbinary such as Zend/zend_compile.h, cause harmless warnings with those
flags.

Both the original warnings and the fix should be harmless.