### PR TITLE
Make duplicate array serialization more efficient in PHP 7.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+2.0.8dev 2018-??-??
+=======
+
+* Be more aggressive about deduplication when generating serialization of arrays in php 7.0+.
+
 2.0.7 2018-06-27
 =======
 

--- a/benchmark/serialize-arrayarray.b.php
+++ b/benchmark/serialize-arrayarray.b.php
@@ -1,0 +1,29 @@
+<?php
+
+// Description: Serialize array of array and unserialize it
+
+require_once 'bench.php';
+
+$b = new Bench('serialize-array-array');
+
+class Obj {
+	private $foo = 10;
+	public $bar = "test";
+	public $i;
+}
+
+$array = array();
+$inner_array = array(array());
+for ($i = 0; $i < 1000; $i++) {
+    $array[] = $inner_array;
+}
+
+for ($i = 0; $i < 40; $i++) {
+	$b->start();
+	for ($j = 0; $j < 2000; $j++) {
+		$ser = igbinary_serialize($array);
+		$unser = igbinary_unserialize($ser);
+	}
+	$b->stop($j);
+	$b->write();
+}

--- a/package.xml
+++ b/package.xml
@@ -34,12 +34,12 @@
  <date>2018-06-27</date>
  <time>16:00:00</time>
  <version>
-  <release>2.0.7</release>
-  <api>1.1.1</api>
+  <release>2.0.8dev</release>
+  <api>1.1.2</api>
  </version>
  <stability>
-  <release>stable</release>
-  <api>stable</api>
+  <release>devel</release>
+  <api>devel</api>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
@@ -155,6 +155,8 @@
     <file name="igbinary_064.phpt" role="test" />
     <file name="igbinary_065.phpt" role="test" />
     <file name="igbinary_065_php5.phpt" role="test" />
+    <file name="igbinary_066.phpt" role="test" />
+    <file name="igbinary_067.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />

--- a/src/php5/igbinary.h
+++ b/src/php5/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "2.0.7"
+#define PHP_IGBINARY_VERSION "2.0.8-dev"
 
 /* Macros */
 #ifdef PHP_WIN32

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "2.0.7"
+#define PHP_IGBINARY_VERSION "2.0.8-dev"
 
 /* Macros */
 

--- a/tests/igbinary_033.phpt
+++ b/tests/igbinary_033.phpt
@@ -6,7 +6,7 @@ if(!extension_loaded('igbinary')) {
 	echo "skip no igbinary";
 }
 --FILE--
-<?php 
+<?php
 
 class Foo {
 	public $parent;
@@ -26,6 +26,7 @@ class Foo {
 		$this->parent = $obj;
 	}
 }
+error_reporting(E_ALL);
 
 $obj1 = new Foo();
 

--- a/tests/igbinary_066.phpt
+++ b/tests/igbinary_066.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Test serializing different empty arrays
+--FILE--
+<?php
+
+// The serialization might be different based on php version and opcache settings.
+// So, test the unserialization instead.
+$a = array();
+var_dump(igbinary_unserialize(igbinary_serialize(array('1st' => array(), '2nd' => array(), '3rd' => array()))));
+echo "\n";
+var_dump(igbinary_unserialize(igbinary_serialize(array('1st' => $a, '2nd' => $a, '3rd' => $a))));
+echo "\n";
+$result = igbinary_unserialize(igbinary_serialize(array('1st' => $a, '2nd' => &$a, '3rd' => &$a, '4th' => array())));
+var_dump($result);
+$result['2nd'][] = 2;
+var_dump($result);
+echo "\n";
+?>
+--EXPECT--
+array(3) {
+  ["1st"]=>
+  array(0) {
+  }
+  ["2nd"]=>
+  array(0) {
+  }
+  ["3rd"]=>
+  array(0) {
+  }
+}
+
+array(3) {
+  ["1st"]=>
+  array(0) {
+  }
+  ["2nd"]=>
+  array(0) {
+  }
+  ["3rd"]=>
+  array(0) {
+  }
+}
+
+array(4) {
+  ["1st"]=>
+  array(0) {
+  }
+  ["2nd"]=>
+  &array(0) {
+  }
+  ["3rd"]=>
+  &array(0) {
+  }
+  ["4th"]=>
+  array(0) {
+  }
+}
+array(4) {
+  ["1st"]=>
+  array(0) {
+  }
+  ["2nd"]=>
+  &array(1) {
+    [0]=>
+    int(2)
+  }
+  ["3rd"]=>
+  &array(1) {
+    [0]=>
+    int(2)
+  }
+  ["4th"]=>
+  array(0) {
+  }
+}

--- a/tests/igbinary_067.phpt
+++ b/tests/igbinary_067.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Test serializing multiple reference groups to the same empty array
+--FILE--
+<?php
+
+function dump($array) {
+	echo count($array) . " values\n";
+	foreach ($array as $k => $value) {
+		echo "$k: " . json_encode($value) . "\n";
+	}
+}
+
+function main() {
+	$a = array();
+	$b = $a;
+	$c = $a;
+	$value = array(&$b, $a, &$b, &$c, &$c);
+	$ser = igbinary_serialize($value);
+	echo bin2hex($ser) . "\n";
+	$v = igbinary_unserialize($ser);
+	dump($v);
+	$v[0][] = 2;
+	dump($v);
+	$v[3][] = 3;
+	dump($v);
+	var_export($a);
+}
+main();
+?>
+--EXPECT--
+000000021405060025140006011400060225010106032514000604250103
+5 values
+0: []
+1: []
+2: []
+3: []
+4: []
+5 values
+0: [2]
+1: []
+2: [2]
+3: []
+4: []
+5 values
+0: [2]
+1: []
+2: [2]
+3: [3]
+4: [3]
+array (
+)


### PR DESCRIPTION
This deduplicates arrays in the serialization if they point
to the same location in memory.
(This does not deduplicate arrays which are equivalent but have
different locations in memory).
PHP 5 is unaffected.

Instead of using the zval pointer of the IS_ARR zval, which would always
be different, use the zend_array storage that it is pointing to.

This assumes that if there are references, they point to different
arrays.

Avoid using ZVAL_EMPTY_ARRAY for now when unserializing,
this would segfault with a naive attempt to use it without extra checks
if the array is immutable (e.g. including the reference count).

- This is less necessary once the changes to aggressively deduplicate
  arrays when serializing are applied
- Unserialization of arrays that are duplicated in many places
  should be faster and use up less memory
  if the new serialization is used.

  The serialization may vary (but be an equivalent representation)
  based on php minor versions and with opcache settings.

Add tests that empty arrays continue to work as expected
(useful to avoid regressions if this uses ZVAL_EMPTY_ARRAY again)

Other changes
- Add miscellaneous micro-optimizations

Related to #182 - Using ZVAL_EMPTY_ARRAY directly when unserializing
would just cause a segfault when combined with references,
without further work.