### PR TITLE
Replace old occurrence of configure.in with configure.ac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ config.status
 config.sub
 configure
 configure.in
+configure.ac
 conftest
 conftest.c
 include


### PR DESCRIPTION
The configure.ac is the recommended file to use instead of the old configure.in which will be removed in autotools future versions.

Thank you...