### PR TITLE
Fix a regression in 2.0.8dev, add a unit test of PHP_INT_MIN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,9 @@ script:
   - phpize
   - ./configure --enable-igbinary
   - make
-  - REPORT_EXIT_STATUS=1 NO_INTERACTION=1 make test
+  - REPORT_EXIT_STATUS=1 NO_INTERACTION=1 TEST_PHP_ARGS="--show-diff" make test
   # For most travis builds, re-run `make test` with valgrind.
-  - if [ "x$SKIP_VALGRIND" = "x" ]; then export TEST_PHP_ARGS="-m"; REPORT_EXIT_STATUS=1 NO_INTERACTION=1 make test; fi
+  - if [ "x$SKIP_VALGRIND" = "x" ]; then export TEST_PHP_ARGS="-m --show-diff"; REPORT_EXIT_STATUS=1 NO_INTERACTION=1 make test; fi
 
 branches:
   only:

--- a/package.xml
+++ b/package.xml
@@ -157,6 +157,8 @@
     <file name="igbinary_065_php5.phpt" role="test" />
     <file name="igbinary_066.phpt" role="test" />
     <file name="igbinary_067.phpt" role="test" />
+    <file name="igbinary_068.phpt" role="test" />
+    <file name="igbinary_069.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -960,7 +960,7 @@ inline static int igbinary_serialize_string(struct igbinary_serialize_data *igsd
 			} else {
 				RETURN_1_IF_NON_ZERO(igbinary_serialize8(igsd, (uint8_t) igbinary_type_string_id32));
 
-				RETURN_1_IF_NON_ZERO(igbinary_serialize8(igsd, igbinary_serialize32(igsd, (uint32_t) value)));
+				RETURN_1_IF_NON_ZERO(igbinary_serialize32(igsd, (uint32_t) value));
 			}
 			return 0;
 		} else if (EXPECTED(result.code == hash_si_code_inserted)) {
@@ -971,8 +971,7 @@ inline static int igbinary_serialize_string(struct igbinary_serialize_data *igsd
 	}
 
 	igsd->string_count++; /* A new string is being serialized - update count so that duplicate class names can be used. */
-	RETURN_1_IF_NON_ZERO(igbinary_serialize_chararray(igsd, ZSTR_VAL(s), len));
-	return 0;
+	return igbinary_serialize_chararray(igsd, ZSTR_VAL(s), len);
 }
 /* }}} */
 /* {{{ igbinary_serialize_chararray */

--- a/tests/igbinary_068.phpt
+++ b/tests/igbinary_068.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test serializing and unserializing PHP_INT_MIN
+--FILE--
+<?php
+
+if (!defined('PHP_INT_MIN')) {
+	define('PHP_INT_MIN', ~PHP_INT_MAX);
+}
+var_export(PHP_INT_MAX === igbinary_unserialize(igbinary_serialize(PHP_INT_MAX)));
+echo "\n";
+
+var_export(PHP_INT_MIN === igbinary_unserialize(igbinary_serialize(PHP_INT_MIN)));
+echo "\n";
+var_export(PHP_INT_MIN+1 === igbinary_unserialize(igbinary_serialize(PHP_INT_MIN + 1)));
+echo "\n";
+?>
+--EXPECT--
+true
+true
+true

--- a/tests/igbinary_069.phpt
+++ b/tests/igbinary_069.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test serializing and unserializing many duplicate strings
+--FILE--
+<?php
+
+function main() {
+	$arr = array();
+	// Just more than 2 ** 16 (`2**16` is a parse error in php 5.5)
+	$n = (1 << 16) + 100;
+	for ($i = 0; $i < $n; $i++) {
+		$s = "$i";
+		$arr[] = $s;
+		$arr[] = $s;
+	}
+	$unser = igbinary_unserialize(igbinary_serialize($arr));
+	var_export($arr === $unser);
+}
+main();
+--EXPECT--
+true


### PR DESCRIPTION
The regression wasn't part of 2.0.7.
It was added to 2.0.8dev when refactoring the code
to serialize references to duplicated strings.
(`igbinary_serialize_string`)

Port some of the micro optimizations to the php5 folder
to keep the code similar