### PR TITLE
Define HAVE_IGBINARY on config.m4

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -82,6 +82,7 @@ if test "$PHP_IGBINARY" != "no"; then
   PHP_INSTALL_HEADERS([ext/igbinary], [igbinary.h $subdir/igbinary.h php_igbinary.h $subdir/php_igbinary.h])
   PHP_NEW_EXTENSION(igbinary, $PHP_IGBINARY_SRC_FILES, $ext_shared,, $PHP_IGBINARY_CFLAGS)
   PHP_ADD_EXTENSION_DEP(igbinary, session, true)
+  AC_DEFINE(HAVE_IGBINARY, 1, [Have igbinary support])
   PHP_ADD_BUILD_DIR($abs_builddir/$subdir, 1)
   PHP_SUBST(IGBINARY_SHARED_LIBADD)
 fi


### PR DESCRIPTION
I was working on an extension dependent on igbinary. To my surprise this macro was defined only in config.w32 and not in config.m4.

This can of course be worked around in dependent projects, but I think a fix belongs upstream.