### PR TITLE
Emit warning and reject if igbinary_unserialize is passed extra data

### DIFF
--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -582,6 +582,13 @@ IGBINARY_API int igbinary_unserialize(const uint8_t *buf, size_t buf_len, zval *
 		return 1;
 	}
 
+	if (igsd.buffer_ptr < igsd.buffer_end) {
+		// https://github.com/igbinary/igbinary/issues/64
+		zend_error(E_WARNING, "igbinary_unserialize: received more data to unserialize than expected");
+		igbinary_unserialize_data_deinit(&igsd);
+		return 1;
+	}
+
 	if (igbinary_finish_wakeup(&igsd)) {
 		igbinary_unserialize_data_deinit(&igsd);
 		return 1;

--- a/tests/igbinary_030_php7.phpt
+++ b/tests/igbinary_030_php7.phpt
@@ -47,32 +47,20 @@ foreach ($datas as $data) {
 	}
 
 	// padded
-	$str .= "98398afa\000y21_ ";
-	$v = igbinary_unserialize($str);
-	if ($v !== $data && !(is_object($data) && $v == $data)) {
-		echo "padded should get original\n";
+	$str2 = $str . "98398afa\000y21_ ";
+	$v = igbinary_unserialize($str2);
+	if ($v !== NULL) {
+		echo "Should return null with padding\n";
 		var_dump($v);
-		echo "vs.\n";
-		var_dump($data);
+	}
+	$str3 = $str . "\x00";
+	$v = igbinary_unserialize($str3);
+	if ($v !== NULL) {
+		echo "Should return null with single byte of padding\n";
+		var_dump($v);
 	}
 }
+echo "Success!\n";
 ?>
 --EXPECT--
-padded should get original
-object(stdClass)#3 (3) {
-  ["0"]=>
-  int(1)
-  ["1"]=>
-  int(2)
-  ["2"]=>
-  int(3)
-}
-vs.
-object(stdClass)#2 (3) {
-  [0]=>
-  int(1)
-  [1]=>
-  int(2)
-  [2]=>
-  int(3)
-}
+Success!

--- a/tests/igbinary_030_php72.phpt
+++ b/tests/igbinary_030_php72.phpt
@@ -46,14 +46,20 @@ foreach ($datas as $data) {
 	}
 
 	// padded
-	$str .= "98398afa\000y21_ ";
-	$v = igbinary_unserialize($str);
-	if ($v !== $data && !(is_object($data) && $v == $data)) {
-		echo "padded should get original\n";
+	$str2 = $str . "98398afa\000y21_ ";
+	$v = igbinary_unserialize($str2);
+	if ($v !== NULL) {
+		echo "Should return null with padding\n";
 		var_dump($v);
-		echo "vs.\n";
-		var_dump($data);
+	}
+	$str3 = $str . "\x00";
+	$v = igbinary_unserialize($str3);
+	if ($v !== NULL) {
+		echo "Should return null with single byte of padding\n";
+		var_dump($v);
 	}
 }
+echo "Success!\n";
 ?>
 --EXPECT--
+Success!


### PR DESCRIPTION
Currently, igbinary will unserialize the data without problems if there
are extra bytes. However, extra bytes likely indicate that the data is
corrupt/malformed.

phpredis and apcu continue to work when tested against
an installation using this branch in PHP 7.1

Fixes #64