### PR TITLE
PHP 8 uses substantially the same API as PHP 7

### DIFF
--- a/igbinary.h
+++ b/igbinary.h
@@ -1,7 +1,7 @@
 #ifndef PHPEXT_IGBINARY_BASE_IGBINARY_H
 #define PHPEXT_IGBINARY_BASE_IGBINARY_H
 #include "php_version.h"
-#if PHP_MAJOR_VERSION == 7
+#if PHP_MAJOR_VERSION == 7 || PHP_MAJOR_VERSION == 8
 #include "src/php7/igbinary.h"
 #else
 #error "Unsupported php version for igbinary build"


### PR DESCRIPTION
Travis config already has PHP `master`, which is now marked as PHP 8.