### PR TITLE
Fix incorrect serialization of 1 in 2**32 billion strings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+3.1.1 2020-01-16
+=======
+
+* Fix bug causing incorrect serialization for 1 in 2**32 strings on 64-bit php installations when string hashes collide.
+  (https://github.com/igbinary/igbinary/issues/260)
+
 3.1.1a1 2020-01-11
 =======
 

--- a/package.xml
+++ b/package.xml
@@ -31,23 +31,20 @@
   <email>tysonandre775@hotmail.com</email>
   <active>yes</active>
  </lead>
- <date>2020-01-11</date>
+ <date>2020-01-16</date>
  <time>16:00:00</time>
  <version>
-  <release>3.1.1a1</release>
+  <release>3.1.1</release>
   <api>1.2.3</api>
  </version>
  <stability>
-  <release>alpha</release>
+  <release>stable</release>
   <api>stable</api>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
-* Throw when an uninitialized php 7.4 typed property is included in the result of __sleep(),
-  instead of emitting a notice and attempting to represent the unset/uninitialized value as null (#258).
-  See https://bugs.php.net/bug.php?id=79002
-
-  Uninitialized properties without types from __sleep continue to emit notices and be represented as null.
+* Fix bug causing incorrect serialization for 1 in 2**32 strings on 64-bit php installations when string hashes collide.
+  (https://github.com/igbinary/igbinary/issues/260)
  </notes>
  <contents>
   <dir name="/">
@@ -182,6 +179,7 @@
     <file name="igbinary_077.phpt" role="test" />
     <file name="igbinary_078.phpt" role="test" />
     <file name="igbinary_079.phpt" role="test" />
+    <file name="igbinary_080.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />
@@ -201,6 +199,42 @@
  <providesextension>igbinary</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2020-01-11</date>
+   <time>16:00:00</time>
+   <version>
+    <release>3.1.1a1</release>
+    <api>1.2.2</api>
+   </version>
+   <stability>
+    <release>beta</release>
+    <api>beta</api>
+   </stability>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Throw when an uninitialized php 7.4 typed property is included in the result of __sleep(),
+  instead of emitting a notice and attempting to represent the unset/uninitialized value as null (#258).
+  See https://bugs.php.net/bug.php?id=79002
+
+  Uninitialized properties without types (from __sleep) continue to cause igbinary to emit notices and are represented as null.
+   </notes>
+  </release>
+  <release>
+   <date>2019-12-27</date>
+   <time>16:00:00</time>
+   <version>
+    <release>3.1.0</release>
+    <api>1.2.2</api>
+   </version>
+   <stability>
+    <release>beta</release>
+    <api>beta</api>
+   </stability>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Same as 3.1.0b4.
+   </notes>
+  </release>
   <release>
    <date>2019-12-20</date>
    <time>16:00:00</time>

--- a/src/php7/hash.h
+++ b/src/php7/hash.h
@@ -27,7 +27,7 @@
  */
 struct hash_si_pair {
 	zend_string *key_zstr; /* Contains key, key length, and key hash */
-	uint32_t key_hash;		/**< Copy of ZSTR_H(key_zstr). Avoid dereferencing key_zstr if hashes are different. */
+	uint32_t key_hash;		/**< Copy of ZSTR_H(key_zstr) (or 1 if hash is truncated to 0). Avoid dereferencing key_zstr if hashes are different. */
 	uint32_t value;		    /**< Value. */
 };
 

--- a/src/php7/hash_si.c
+++ b/src/php7/hash_si.c
@@ -172,7 +172,13 @@ struct hash_si_result hash_si_find_or_insert(struct hash_si *h, zend_string *key
 	struct hash_si_result result;
 	struct hash_si_pair *pair;
 	uint32_t key_hash = ZSTR_HASH(key_zstr);
-
+#if SIZEOF_ZEND_LONG > 4
+	if (UNEXPECTED(key_hash == 0)) {
+		/* A key_hash of uint32_t(0) would be treated like a gap when inserted. Change the hash used to 1 instead. */
+		/* ZSTR_HASH is non-zero, but the lower bits can be 0 */
+		key_hash = 1;
+	}
+#endif
 	pair = _hash_si_find(h, key_zstr, key_hash);
 
 	if (pair->key_zstr == NULL) {

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.1.1a1"
+#define PHP_IGBINARY_VERSION "3.1.1"
 
 /* Macros */
 

--- a/tests/igbinary_080.phpt
+++ b/tests/igbinary_080.phpt
@@ -1,0 +1,26 @@
+--TEST--
+igbinary with hash collision serializing strings
+--FILE--
+<?php
+$var=['id'=>"3010480803", 'user_id'=>12346];
+$serialized = igbinary_serialize($var);
+$unserialized = igbinary_unserialize($serialized);
+var_dump($unserialized);
+$var=['id'=>"3010480803", 'user_id'=>"3010480804"];
+$serialized = igbinary_serialize($var);
+$unserialized = igbinary_unserialize($serialized);
+var_dump($unserialized);
+?>
+--EXPECT--
+array(2) {
+  ["id"]=>
+  string(10) "3010480803"
+  ["user_id"]=>
+  int(12346)
+}
+array(2) {
+  ["id"]=>
+  string(10) "3010480803"
+  ["user_id"]=>
+  string(10) "3010480804"
+}


### PR DESCRIPTION
(When those strings' hashes have a lower 4 bytes of 0
on 64 bit platforms)

Fixes #260