### PR TITLE
Fix APCu tests

### DIFF
--- a/tests/igbinary_045b.phpt
+++ b/tests/igbinary_045b.phpt
@@ -14,7 +14,6 @@ if (version_compare($ext->getVersion(), '4.0.2', '<')) {
 --INI--
 apc.enable_cli=1
 apc.serializer=igbinary
-extension=apcu.so
 --FILE--
 <?php
 echo ini_get('apc.serializer'), "\n";

--- a/tests/igbinary_045c.phpt
+++ b/tests/igbinary_045c.phpt
@@ -3,7 +3,6 @@ APCu serializer registration - more data types
 --INI--
 apc.enable_cli=1
 apc.serializer=igbinary
-extension=apcu.so
 --SKIPIF--
 <?php
 if (!extension_loaded('apcu')) {


### PR DESCRIPTION
Tests defines `extension=apcu.so` as `INI` addition but this tests are skipped if extension is not already loaded

so running this tests brings
```
SKIP APCu serializer registration [src/igbinary-3.1.2/tests/igbinary_045b.phpt] reason: APCu not loaded
```
If I enable module tests work but noticing load `apcu.so` twice
```
igbinary-3.1.2/tests$ cat igbinary_045b.diff 
001+ PHP Warning:  Module 'apcu' already loaded in Unknown on line 0
002+ 
003+ Warning: Module 'apcu' already loaded in Unknown on line 0
```

Removal of this lines allows to pass this tests