### PR TITLE
Fix igbinary_serialize incorrectly deduplicating arrays/objects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_style = tab
 indent_size = 4
 [*.phpt]
 indent_style = space
+[*.xml]
+indent_size = 1
+indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   # Allow valgrind+7.4 to fail due to false positive leaks reported by valgrind in zend_string_equals (implementation uses custom assembly).
   - php: 7.4
     env: CC=gcc CFLAGS=""
-  - php: nightly
   exclude:
   - php: 7.0
     env: CC=clang   CFLAGS="-g -O0"

--- a/package.xml
+++ b/package.xml
@@ -31,20 +31,19 @@
   <email>tysonandre775@hotmail.com</email>
   <active>yes</active>
  </lead>
- <date>2020-09-02</date>
+ <date>2020-10-07</date>
  <time>16:00:00</time>
  <version>
-  <release>3.1.5</release>
-  <api>1.2.3</api>
+  <release>3.1.6RC1</release>
+  <api>1.2.4</api>
  </version>
  <stability>
-  <release>stable</release>
+  <release>beta</release>
   <api>stable</api>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
-* Update unit test expectation to match behavior in php 8 due to changes in php's handling of cyclic references in arrays.
-* Support API changes in php 8.0.0beta3.
+* Fix igbinary_serialize incorrectly deduplicating arrays/objects/references when they were garbage collected/freed during serialization.
  </notes>
  <contents>
   <dir name="/">
@@ -93,6 +92,8 @@
     <file name="__serialize_017.phpt" role="test" />
     <file name="__serialize_018.phpt" role="test" />
     <file name="__serialize_019.phpt" role="test" />
+    <file name="__serialize_020.phpt" role="test" />
+    <file name="__serialize_021.phpt" role="test" />
     <file name="igbinary_001.phpt" role="test" />
     <file name="igbinary_002.phpt" role="test" />
     <file name="igbinary_003.phpt" role="test" />
@@ -205,6 +206,23 @@
  <providesextension>igbinary</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+  <date>2020-09-02</date>
+  <time>16:00:00</time>
+  <version>
+   <release>3.1.5</release>
+   <api>1.2.3</api>
+  </version>
+  <stability>
+   <release>stable</release>
+   <api>stable</api>
+  </stability>
+  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+  <notes>
+* Update unit test expectation to match behavior in php 8 due to changes in php's handling of cyclic references in arrays.
+* Support API changes in php 8.0.0beta3.
+  </notes>
+  </release>
   <release>
    <date>2020-08-05</date>
    <time>16:00:00</time>

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -22,7 +22,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.1.5"
+#define PHP_IGBINARY_VERSION "3.1.6RC1"
 
 /* Macros */
 

--- a/tests/__serialize_020.phpt
+++ b/tests/__serialize_020.phpt
@@ -1,0 +1,644 @@
+--TEST--
+issue when serializing/deserializing nested objects with __serialize
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) { echo "skip uses php 7.1 syntax\n"; } ?>
+--FILE--
+<?php
+// Based on bug report seen in a Symfony codebase - https://github.com/igbinary/igbinary/issues/287
+// NOTE: This test would also pass in older php versions, where igbinary doesn't call __serialize,
+// just because we're returning the same data we fetch.
+// (However, the serialized data generated before/after 7.4 would be incompatible if saved to memcache, etc.)
+class Event
+{
+    private $propagationStopped = false;
+}
+
+class MessageEvents
+{
+    private $events = [];
+    private $transports = [];
+
+    public function add(MessageEvent $event): void
+    {
+        $this->events[] = $event;
+        $this->transports[$event->getTransport()] = true;
+    }
+
+    public function getEvents(string $name = null): array
+    {
+        return $this->events;
+    }
+}
+
+final class MessageEvent extends Event
+{
+    private $message;
+    private $envelope;
+    private $transport;
+    private $queued;
+
+    public function __construct(RawMessage $message, Envelope $envelope, string $transport, bool $queued = false)
+    {
+        $this->message = $message;
+        $this->envelope = $envelope;
+        $this->transport = $transport;
+        $this->queued = $queued;
+    }
+
+    public function getTransport(): string
+    {
+        return $this->transport;
+    }
+
+    public function getMessage(): RawMessage
+    {
+        return $this->message;
+    }
+}
+
+class Envelope
+{
+    private $sender;
+    private $recipients = [];
+
+    public function __construct(Address $sender, array $recipients)
+    {
+        $this->setSender($sender);
+        $this->setRecipients($recipients);
+    }
+
+    public static function create(RawMessage $message): self
+    {
+        return new DelayedEnvelope($message);
+    }
+
+    public function setSender(Address $sender): void
+    {
+        $this->sender = $sender;
+    }
+
+    public function setRecipients(array $recipients): void
+    {
+        $this->recipients = [];
+        foreach ($recipients as $recipient) {
+            $this->recipients[] = new Address($recipient->getAddress());
+        }
+    }
+
+    public function getRecipients(): array
+    {
+        return $this->recipients;
+    }
+}
+
+final class DelayedEnvelope extends Envelope
+{
+    private $senderSet = false;
+    private $recipientsSet = false;
+    private $message;
+
+    public function __construct(Message $message)
+    {
+        $this->message = $message;
+    }
+
+    public function setSender(Address $sender): void
+    {
+        parent::setSender($sender);
+
+        $this->senderSet = true;
+    }
+
+    public function setRecipients(array $recipients): void
+    {
+        parent::setRecipients($recipients);
+
+        $this->recipientsSet = parent::getRecipients();
+    }
+}
+
+final class Address
+{
+    private $address;
+    private $name;
+
+    public function __construct(string $address, string $name = '')
+    {
+        $this->address = trim($address);
+        $this->name = trim(str_replace(["\n", "\r"], '', $name));
+    }
+
+    /**
+     * @param Address|string $address
+     */
+    public static function create($address): self
+    {
+        if ($address instanceof self) {
+            return $address;
+        }
+        if (\is_string($address)) {
+            if (false === strpos($address, '<')) {
+                return new self($address);
+            }
+
+            return new self($matches['addrSpec'], trim($matches['displayName'], ' \'"'));
+        }
+
+        throw new InvalidArgumentException(sprintf('An address can be an instance of Address or a string ("%s" given).', get_debug_type($address)));
+    }
+
+    public static function createArray(array $addresses): array
+    {
+        $addrs = [];
+        foreach ($addresses as $address) {
+            $addrs[] = self::create($address);
+        }
+
+        return $addrs;
+    }
+}
+
+abstract class AbstractHeader
+{
+    private static $encoder;
+
+    private $name;
+    private $lineLength = 76;
+    private $lang;
+    private $charset = 'utf-8';
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+}
+
+final class Headers
+{
+    private $headers = [];
+    private $lineLength = 76;
+
+    public function __construct(...$headers)
+    {
+        foreach ($headers as $header) {
+            $this->add($header);
+        }
+    }
+
+    public function __clone()
+    {
+        foreach ($this->headers as $name => $collection) {
+            foreach ($collection as $i => $header) {
+                $this->headers[$name][$i] = clone $header;
+            }
+        }
+    }
+
+    public function addMailboxListHeader(string $name, array $addresses): self
+    {
+        return $this->add(new MailboxListHeader($name, Address::createArray($addresses)));
+    }
+
+    public function add($header): self
+    {
+        self::checkHeaderClass($header);
+
+        $name = strtolower($header->getName());
+
+        $this->headers[$name][] = $header;
+
+        return $this;
+    }
+
+    public function get(string $name)
+    {
+        $name = strtolower($name);
+        if (!isset($this->headers[$name])) {
+            return null;
+        }
+
+        $values = array_values($this->headers[$name]);
+
+        return array_shift($values);
+    }
+
+    public function all(string $name = null): iterable
+    {
+        if (null === $name) {
+            foreach ($this->headers as $name => $collection) {
+                foreach ($collection as $header) {
+                    yield $name => $header;
+                }
+            }
+        } elseif (isset($this->headers[strtolower($name)])) {
+            foreach ($this->headers[strtolower($name)] as $header) {
+                yield $header;
+            }
+        }
+    }
+
+    public static function checkHeaderClass($header): void
+    {
+        $name = strtolower($header->getName());
+    }
+}
+
+final class MailboxListHeader extends AbstractHeader
+{
+    private $addresses = [];
+
+    public function __construct(string $name, array $addresses)
+    {
+        parent::__construct($name);
+
+        $this->addAddresses($addresses);
+    }
+
+    public function addAddresses(array $addresses)
+    {
+        foreach ($addresses as $address) {
+            $this->addAddress($address);
+        }
+    }
+
+    /**
+     * @throws RfcComplianceException
+     */
+    public function addAddress(Address $address)
+    {
+        $this->addresses[] = $address;
+    }
+}
+
+class RawMessage
+{
+    private $message;
+
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    public function __serialize(): array
+    {
+        return [$this->message];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->message] = $data;
+    }
+}
+
+class Message extends RawMessage
+{
+    private $headers;
+    private $body;
+
+    public function __construct(Headers $headers = null, AbstractPart $body = null)
+    {
+        $this->headers = $headers ? clone $headers : new Headers();
+        $this->body = $body;
+    }
+
+    public function __clone()
+    {
+        $this->headers = clone $this->headers;
+
+        if (null !== $this->body) {
+            $this->body = clone $this->body;
+        }
+    }
+
+    public function getHeaders(): Headers { return $this->headers; }
+
+    public function __serialize(): array
+    {
+        return [$this->headers];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->headers] = $data;
+    }
+}
+
+
+class Email extends Message
+{
+    private $text;
+    private $textCharset;
+    private $html;
+    private $htmlCharset;
+    private $attachments = [];
+    public function to(...$addresses)
+    {
+        return $this->setListAddressHeaderBody('To', $addresses);
+    }
+
+    private function setListAddressHeaderBody(string $name, array $addresses)
+    {
+        $addresses = Address::createArray($addresses);
+        $headers = $this->getHeaders();
+        $headers->addMailboxListHeader($name, $addresses);
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function __serialize(): array
+    {
+        return [$this->text, $this->textCharset, $this->html, $this->htmlCharset, $this->attachments, parent::__serialize()];
+    }
+
+    /**
+     * @internal
+     */
+    public function __unserialize(array $data): void
+    {
+        [$this->text, $this->textCharset, $this->html, $this->htmlCharset, $this->attachments, $parentData] = $data;
+
+        parent::__unserialize($parentData);
+    }
+}
+
+$messageEvents = new MessageEvents();
+$messageEvents->add(new MessageEvent($message1 = (new Email())->to('alice@example.com'), Envelope::create($message1), 'null://null'));
+$messageEvents->add(new MessageEvent($message2 = (new Email())->to('bob@example.com'), Envelope::create($message2), 'null://null'));
+
+var_dump($messageEvents); // Comment/uncomment to trigger the bug
+
+var_dump('headers_before', $messageEvents->getEvents()[0]->getMessage()->getHeaders() === $messageEvents->getEvents()[1]->getMessage()->getHeaders());
+
+$ser = igbinary_serialize($messageEvents);
+
+$messageEvents = igbinary_unserialize($ser);
+
+// should dump "false", but dumps "true" the "var_dump($messageEvents)" is not commented
+var_dump('headers_after', $messageEvents->getEvents()[0]->getMessage()->getHeaders() === $messageEvents->getEvents()[1]->getMessage()->getHeaders());
+?>
+--EXPECT--
+object(MessageEvents)#1 (2) {
+  ["events":"MessageEvents":private]=>
+  array(2) {
+    [0]=>
+    object(MessageEvent)#2 (5) {
+      ["message":"MessageEvent":private]=>
+      object(Email)#3 (8) {
+        ["text":"Email":private]=>
+        NULL
+        ["textCharset":"Email":private]=>
+        NULL
+        ["html":"Email":private]=>
+        NULL
+        ["htmlCharset":"Email":private]=>
+        NULL
+        ["attachments":"Email":private]=>
+        array(0) {
+        }
+        ["headers":"Message":private]=>
+        object(Headers)#4 (2) {
+          ["headers":"Headers":private]=>
+          array(1) {
+            ["to"]=>
+            array(1) {
+              [0]=>
+              object(MailboxListHeader)#6 (5) {
+                ["addresses":"MailboxListHeader":private]=>
+                array(1) {
+                  [0]=>
+                  object(Address)#5 (2) {
+                    ["address":"Address":private]=>
+                    string(17) "alice@example.com"
+                    ["name":"Address":private]=>
+                    string(0) ""
+                  }
+                }
+                ["name":"AbstractHeader":private]=>
+                string(2) "To"
+                ["lineLength":"AbstractHeader":private]=>
+                int(76)
+                ["lang":"AbstractHeader":private]=>
+                NULL
+                ["charset":"AbstractHeader":private]=>
+                string(5) "utf-8"
+              }
+            }
+          }
+          ["lineLength":"Headers":private]=>
+          int(76)
+        }
+        ["body":"Message":private]=>
+        NULL
+        ["message":"RawMessage":private]=>
+        NULL
+      }
+      ["envelope":"MessageEvent":private]=>
+      object(DelayedEnvelope)#7 (5) {
+        ["senderSet":"DelayedEnvelope":private]=>
+        bool(false)
+        ["recipientsSet":"DelayedEnvelope":private]=>
+        bool(false)
+        ["message":"DelayedEnvelope":private]=>
+        object(Email)#3 (8) {
+          ["text":"Email":private]=>
+          NULL
+          ["textCharset":"Email":private]=>
+          NULL
+          ["html":"Email":private]=>
+          NULL
+          ["htmlCharset":"Email":private]=>
+          NULL
+          ["attachments":"Email":private]=>
+          array(0) {
+          }
+          ["headers":"Message":private]=>
+          object(Headers)#4 (2) {
+            ["headers":"Headers":private]=>
+            array(1) {
+              ["to"]=>
+              array(1) {
+                [0]=>
+                object(MailboxListHeader)#6 (5) {
+                  ["addresses":"MailboxListHeader":private]=>
+                  array(1) {
+                    [0]=>
+                    object(Address)#5 (2) {
+                      ["address":"Address":private]=>
+                      string(17) "alice@example.com"
+                      ["name":"Address":private]=>
+                      string(0) ""
+                    }
+                  }
+                  ["name":"AbstractHeader":private]=>
+                  string(2) "To"
+                  ["lineLength":"AbstractHeader":private]=>
+                  int(76)
+                  ["lang":"AbstractHeader":private]=>
+                  NULL
+                  ["charset":"AbstractHeader":private]=>
+                  string(5) "utf-8"
+                }
+              }
+            }
+            ["lineLength":"Headers":private]=>
+            int(76)
+          }
+          ["body":"Message":private]=>
+          NULL
+          ["message":"RawMessage":private]=>
+          NULL
+        }
+        ["sender":"Envelope":private]=>
+        NULL
+        ["recipients":"Envelope":private]=>
+        array(0) {
+        }
+      }
+      ["transport":"MessageEvent":private]=>
+      string(11) "null://null"
+      ["queued":"MessageEvent":private]=>
+      bool(false)
+      ["propagationStopped":"Event":private]=>
+      bool(false)
+    }
+    [1]=>
+    object(MessageEvent)#8 (5) {
+      ["message":"MessageEvent":private]=>
+      object(Email)#9 (8) {
+        ["text":"Email":private]=>
+        NULL
+        ["textCharset":"Email":private]=>
+        NULL
+        ["html":"Email":private]=>
+        NULL
+        ["htmlCharset":"Email":private]=>
+        NULL
+        ["attachments":"Email":private]=>
+        array(0) {
+        }
+        ["headers":"Message":private]=>
+        object(Headers)#10 (2) {
+          ["headers":"Headers":private]=>
+          array(1) {
+            ["to"]=>
+            array(1) {
+              [0]=>
+              object(MailboxListHeader)#12 (5) {
+                ["addresses":"MailboxListHeader":private]=>
+                array(1) {
+                  [0]=>
+                  object(Address)#11 (2) {
+                    ["address":"Address":private]=>
+                    string(15) "bob@example.com"
+                    ["name":"Address":private]=>
+                    string(0) ""
+                  }
+                }
+                ["name":"AbstractHeader":private]=>
+                string(2) "To"
+                ["lineLength":"AbstractHeader":private]=>
+                int(76)
+                ["lang":"AbstractHeader":private]=>
+                NULL
+                ["charset":"AbstractHeader":private]=>
+                string(5) "utf-8"
+              }
+            }
+          }
+          ["lineLength":"Headers":private]=>
+          int(76)
+        }
+        ["body":"Message":private]=>
+        NULL
+        ["message":"RawMessage":private]=>
+        NULL
+      }
+      ["envelope":"MessageEvent":private]=>
+      object(DelayedEnvelope)#13 (5) {
+        ["senderSet":"DelayedEnvelope":private]=>
+        bool(false)
+        ["recipientsSet":"DelayedEnvelope":private]=>
+        bool(false)
+        ["message":"DelayedEnvelope":private]=>
+        object(Email)#9 (8) {
+          ["text":"Email":private]=>
+          NULL
+          ["textCharset":"Email":private]=>
+          NULL
+          ["html":"Email":private]=>
+          NULL
+          ["htmlCharset":"Email":private]=>
+          NULL
+          ["attachments":"Email":private]=>
+          array(0) {
+          }
+          ["headers":"Message":private]=>
+          object(Headers)#10 (2) {
+            ["headers":"Headers":private]=>
+            array(1) {
+              ["to"]=>
+              array(1) {
+                [0]=>
+                object(MailboxListHeader)#12 (5) {
+                  ["addresses":"MailboxListHeader":private]=>
+                  array(1) {
+                    [0]=>
+                    object(Address)#11 (2) {
+                      ["address":"Address":private]=>
+                      string(15) "bob@example.com"
+                      ["name":"Address":private]=>
+                      string(0) ""
+                    }
+                  }
+                  ["name":"AbstractHeader":private]=>
+                  string(2) "To"
+                  ["lineLength":"AbstractHeader":private]=>
+                  int(76)
+                  ["lang":"AbstractHeader":private]=>
+                  NULL
+                  ["charset":"AbstractHeader":private]=>
+                  string(5) "utf-8"
+                }
+              }
+            }
+            ["lineLength":"Headers":private]=>
+            int(76)
+          }
+          ["body":"Message":private]=>
+          NULL
+          ["message":"RawMessage":private]=>
+          NULL
+        }
+        ["sender":"Envelope":private]=>
+        NULL
+        ["recipients":"Envelope":private]=>
+        array(0) {
+        }
+      }
+      ["transport":"MessageEvent":private]=>
+      string(11) "null://null"
+      ["queued":"MessageEvent":private]=>
+      bool(false)
+      ["propagationStopped":"Event":private]=>
+      bool(false)
+    }
+  }
+  ["transports":"MessageEvents":private]=>
+  array(1) {
+    ["null://null"]=>
+    bool(true)
+  }
+}
+string(14) "headers_before"
+bool(false)
+string(13) "headers_after"
+bool(false)

--- a/tests/__serialize_021.phpt
+++ b/tests/__serialize_021.phpt
@@ -1,0 +1,49 @@
+--TEST--
+__serialize() mechanism (021): Temporary references in serialized arrays should be properly deduplicated
+--FILE--
+<?php
+
+// This test will also pass before php 7.4 - it will just not call __serialize in older php versions.
+// (not a good example, the formats are incompatible)
+class Test {
+    /** @var int */
+    public $i;
+
+    public function __construct(int $i) {
+        $this->i = $i;
+    }
+
+    public function __serialize() {
+        $j = $this->i + 0x7700;
+        return [&$j, &$j];
+    }
+
+    public function __unserialize(array $data) {
+        list($this->i) = $data;
+    }
+}
+
+$values = [];
+for ($i = 0; $i < 256; $i++) {
+    $values[] = new Test($i);
+}
+$ser = igbinary_serialize($values);
+$result = igbinary_unserialize($ser);
+
+printf("Count=%d\n", count($values));
+$j = 0;
+foreach ($values as $i => $v) {
+    if ($i !== $j) {
+        echo "Unexpected key $i, expected $j\n";
+    }
+    if ($v->i !== $j) {
+        echo "Unexpected value {$v->i}, expected $j\n";
+    }
+    $j++;
+}
+echo "Done\n";
+
+?>
+--EXPECT--
+Count=256
+Done


### PR DESCRIPTION
... That are freed

For example, this can be seen when `__serialize` returns an array that
contains a temporary array.
Before, because the result of `__serialize` was immediately freed,
another array could be created with the exact same memory address,
and igbinary would incorrectly assume they're duplicates.

Incorrect deduplication can be avoided by keeping references to all
serialized arrays/objects around in memory.
~~TODO: Add additional checks/tests for references.~~ (done)

This may affect the performance of serialization.

Fixes #287
Based on #288