### PR TITLE
Emit deprecation notice when serializing resources

### DIFF
--- a/.azure/job.yml
+++ b/.azure/job.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
     # E.g. ondrej/php sometimes updates the latest version
     - script: |
-      displayName: 'Refresh apt-get'
-    - script: |
         sudo apt-get install -y valgrind
       displayName: 'Install valgrind'
     - script: |

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-3.1.7dev 202?-??-??
+3.2.0dev 202?-??-??
 =======
 
 * Use PHP's shared empty array instance when unserializing empty arrays in php 7.3+.

--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,9 @@
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
 * Improve memory efficiency when unserializing packed arrays (e.g. lists) - certain checks are no longer needed.
+* Emit a deprecation notice when serializing resources.
+  PHP itself is converting many resources to objects that throw an Error on serialization attempts.
+  Continue to represent resources as null in the serialized data.
  </notes>
  <contents>
   <dir name="/">

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.1.7dev"
+#define PHP_IGBINARY_VERSION "3.2.0dev"
 
 /* Macros */
 

--- a/tests/igbinary_023.phpt
+++ b/tests/igbinary_023.phpt
@@ -22,7 +22,15 @@ test('resource', $res, false);
 
 fclose($res);
 
---EXPECT--
+test('resource', $res, false);
+
+--EXPECTF--
+Deprecated: igbinary_serialize(): Cannot serialize resource(stream) and resources may be converted to objects that cannot be serialized in future php releases. Serializing the value as null instead in %sigbinary_023.php on line 4
+resource
+00
+OK
+
+Deprecated: igbinary_serialize(): Cannot serialize resource(Unknown) and resources may be converted to objects that cannot be serialized in future php releases. Serializing the value as null instead in %sigbinary_023.php on line 4
 resource
 00
 OK


### PR DESCRIPTION
PHP itself is converting many resources to objects that throw an Error on
serialization attempts starting in php 8.0.
Continue to represent resources as null in the serialized data.

Fixes #300