### PR TITLE
Properly handle edge cases in unserializing duplicates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,12 +36,12 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.0rc1
+                  PHP_VER: 8.0.0
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.0rc1
+                  PHP_VER: 8.0.0
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x64
@@ -86,22 +86,22 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.3.23
+                  PHP_VER: 7.3.25
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.3.23
+                  PHP_VER: 7.3.25
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.4.11
+                  PHP_VER: 7.4.13
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.4.11
+                  PHP_VER: 7.4.13
                   TS: 0
 
 build_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,17 @@ matrix:
     env: CC=gcc CXX=g++ USE_32BIT=1 PHP_CUSTOM=maintainer-zts PHP_CONFIGURE_ARGS='--disable-all --enable-maintainer-zts --enable-debug --enable-cgi --enable-session --enable-json' SKIP_VALGRIND=1
     dist: focal
 
+  - php: 8.0
+    env: CC=gcc CFLAGS="" SKIP_VALGRIND=1
+    dist: focal
+  - php: 8.0
+    env: CC=gcc CFLAGS="-g -O0 -fstack-protector -fstack-protector-all" SKIP_VALGRIND=1
+    dist: focal
+  # valgrind reports "WARNING: unhandled x86-linux syscall: 403"
+  - php: 8.0
+    env: CC=gcc CXX=g++ USE_32BIT=1 PHP_CUSTOM=maintainer-zts PHP_CONFIGURE_ARGS='--disable-all --enable-maintainer-zts --enable-debug --enable-cgi --enable-session --enable-json' SKIP_VALGRIND=1
+    dist: focal
+
   - php: 7.4
     env: CC=gcc CFLAGS="-g -O0 -fstack-protector -fstack-protector-all" SKIP_VALGRIND=1
     dist: focal

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,11 @@
 3.2.0dev 202?-??-??
 =======
 
-* Use PHP's shared empty array instance when unserializing empty arrays in php 7.3+.
-  (helps slightly with memory usage when repeatedly unserializing,
-  when removing elements from arrays before unserializing them,
-  or when serializing values including an empty array that was unserialized)
+* Improve memory efficiency when unserializing packed arrays (e.g. lists) - certain checks are no longer needed.
+* Emit a deprecation notice when serializing resources.
+  PHP itself is converting many resources to objects that throw an Error on serialization attempts.
+  Continue to represent resources as null in the serialized data.
+* Fix memory management bug when unserializing invalid data (duplicate properties in objects (e.g. from `__sleep`) or duplicate fields in arrays (impossible for valid data)).
 
 3.1.6 2020-10-08
 =======

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 - Data portability between platforms (32/64bit, endianness)
 - Tested on Linux amd64, Linux ARM, Mac OSX x86, HP-UX PA-RISC and NetBSD sparc64
 - Hooks up to the APCu in-memory key-value store as a serialization handler.
-- Compatible with 7.0 &ndash; 7.4 (The older igbinary [2.x releases](https://github.com/igbinary/igbinary/tree/v2) support 5.2 &ndash; 5.6, 7.0 &ndash; 7.3)
+- Compatible with 7.0 &ndash; 8.0 (The older igbinary [2.x releases](https://github.com/igbinary/igbinary/tree/v2) support 5.2 &ndash; 5.6, 7.0 &ndash; 7.3)
 
 Implementation details
 ----------------------
@@ -92,7 +92,9 @@ Installing
 
 If PHP was installed through your package manager,
 the package manager may also contain prebuilt packages for `igbinary`
-(with a package name similar to php-igbinary)
+(with a package name similar to php-igbinary).
+
+- The packages from some package managers and OS versions may be out of date and have known bugs. The latest release of igbinary is [![The Latest Stable Version](https://img.shields.io/github/v/release/igbinary/igbinary.svg)](https://github.com/igbinary/igbinary/releases)
 
 Igbinary may also be installed with the command `pecl install igbinary` (You will need to enable igbinary in php.ini)
 

--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,7 @@
  <date>2020-10-08</date>
  <time>16:00:00</time>
  <version>
-  <release>3.1.7dev</release>
+  <release>3.2.0dev</release>
   <api>1.2.5</api>
  </version>
  <stability>
@@ -47,6 +47,7 @@
 * Emit a deprecation notice when serializing resources.
   PHP itself is converting many resources to objects that throw an Error on serialization attempts.
   Continue to represent resources as null in the serialized data.
+* Fix memory management bug when unserializing invalid data (duplicate properties in objects (e.g. from `__sleep`) or duplicate fields in arrays (impossible for valid data)).
  </notes>
  <contents>
   <dir name="/">
@@ -191,6 +192,10 @@
     <file name="igbinary_081.phpt" role="test" />
     <file name="igbinary_082.phpt" role="test" />
     <file name="igbinary_082_php74.phpt" role="test" />
+    <file name="igbinary_083.phpt" role="test" />
+    <file name="igbinary_084.phpt" role="test" />
+    <file name="igbinary_084b.phpt" role="test" />
+    <file name="igbinary_085.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />

--- a/tests/igbinary_083.phpt
+++ b/tests/igbinary_083.phpt
@@ -1,0 +1,39 @@
+--TEST--
+igbinary object with reference to ArrayObject
+--FILE--
+<?php
+
+class UnSerializable implements Serializable
+{
+    public function serialize() {
+        echo "Called serialize\n";
+    }
+    public function unserialize($serialized) {
+        echo "Called unserialize\n";
+    }
+}
+
+$unser = new UnSerializable();
+$arr = [$unser];
+$arr[1] = &$arr[0];
+$arr[2] = 'endcap';
+$arr[3] = &$arr[2];
+
+$data = igbinary_serialize($arr);
+echo urlencode($data) . PHP_EOL;
+$recovered = igbinary_unserialize($data);
+var_dump($recovered);
+?>
+--EXPECT--
+Called serialize
+%00%00%00%02%14%04%06%00%25%00%06%01%25%22%01%06%02%25%11%06endcap%06%03%25%01%02
+array(4) {
+  [0]=>
+  &NULL
+  [1]=>
+  &NULL
+  [2]=>
+  &string(6) "endcap"
+  [3]=>
+  &string(6) "endcap"
+}

--- a/tests/igbinary_084.phpt
+++ b/tests/igbinary_084.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Properly free duplicate properties when unserializing invalid data
+--FILE--
+<?php
+class Test {
+    public $pub;
+    public function __sleep() {
+        // TODO: Could start detecting duplicates and emitting a notice as well
+        return ["pub", "pub"];
+    }
+}
+$t = new Test();
+$t->pub = new Test();
+$s = igbinary_serialize($t);
+echo urlencode($s), "\n";
+$unser = igbinary_unserialize($s);
+var_dump($unser);
+?>
+--EXPECT--
+%00%00%00%02%17%04Test%14%02%11%03pub%1A%00%14%02%0E%01%00%0E%01%00%0E%01%22%01
+object(Test)#3 (1) {
+  ["pub"]=>
+  object(Test)#4 (1) {
+    ["pub"]=>
+    NULL
+  }
+}

--- a/tests/igbinary_084b.phpt
+++ b/tests/igbinary_084b.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Properly free duplicate undeclared properties when unserializing invalid data
+--FILE--
+<?php
+class Test {
+    public function __construct( ) {
+        $this->pub = null;
+    }
+
+    public function __sleep() {
+        // TODO: Could start detecting duplicates and emitting a notice as well
+        return ["pub", "pub"];
+    }
+}
+$t = new Test();
+$t->pub = new Test();
+$s = igbinary_serialize($t);
+echo urlencode($s), "\n";
+$unser = igbinary_unserialize($s);
+var_dump($unser);
+?>
+--EXPECT--
+%00%00%00%02%17%04Test%14%02%11%03pub%1A%00%14%02%0E%01%00%0E%01%00%0E%01%22%01
+object(Test)#3 (1) {
+  ["pub"]=>
+  object(Test)#4 (1) {
+    ["pub"]=>
+    NULL
+  }
+}

--- a/tests/igbinary_085.phpt
+++ b/tests/igbinary_085.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Properly free unexpected duplicate fields when unserializing arrays
+--FILE--
+<?php
+// Duplicate fields wouldn't be created by calls to igbinary_serialize,
+// but make sure to handle them when unserializing corrupt data.
+$s = new stdClass();
+$ser = igbinary_serialize(['xx' => $s, 'yy' => $s]);
+echo urlencode($ser), "\n";
+$result = igbinary_unserialize(str_replace('xx', 'yy', $ser));
+var_dump($result);
+$ser = igbinary_serialize([0x66 => $s, 0x77 => $s]);
+echo urlencode($ser), "\n";
+$result2 = igbinary_unserialize(str_replace("\x66", "\x77", $ser));
+var_dump($result2);
+?>
+--EXPECT--
+%00%00%00%02%14%02%11%02xx%17%08stdClass%14%00%11%02yy%22%01
+array(1) {
+  ["yy"]=>
+  object(stdClass)#2 (0) {
+  }
+}
+%00%00%00%02%14%02%06f%17%08stdClass%14%00%06w%22%01
+array(1) {
+  [119]=>
+  object(stdClass)#3 (0) {
+  }
+}


### PR DESCRIPTION
Defer freeing memory of overwritten properties or array fields.