### PR TITLE
More optimizations, change handling of __PHP_Incomplete_Class

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -60,6 +60,7 @@
    <file name="src/php7/hash_ptr.h" role="src" />
    <file name="src/php7/hash_si.c" role="src" />
    <file name="src/php7/hash_si_ptr.c" role="src" />
+   <file name="src/php7/igbinary_bswap.h" role="src" />
    <file name="src/php7/igbinary.c" role="src" />
    <file name="src/php7/igbinary.h" role="src" />
    <file name="src/php7/igbinary_macros.h" role="src" />

--- a/src/php7/hash_si.c
+++ b/src/php7/hash_si.c
@@ -54,17 +54,16 @@ int hash_si_init(struct hash_si *h, uint32_t size) {
 /* {{{ hash_si_deinit */
 void hash_si_deinit(struct hash_si *h) {
 	size_t i;
+	const size_t mask = h->mask;
+	struct hash_si_pair *const data = h->data;
 
-	for (i = 0; i <= h->mask; i++) {
-		if (h->data[i].key_zstr != NULL) {
-			zend_string_release(h->data[i].key_zstr);
+	for (i = 0; i <= mask; i++) {
+		if (data[i].key_zstr != NULL) {
+			zend_string_release(data[i].key_zstr);
 		}
 	}
 
-	efree(h->data);
-
-	h->mask = 0;
-	h->used = 0;
+	efree(data);
 }
 /* }}} */
 /* {{{ get_key_hash */

--- a/src/php7/igbinary_bswap.h
+++ b/src/php7/igbinary_bswap.h
@@ -1,0 +1,71 @@
+#ifndef IGBINARY_BSWAP
+#define IGBINARY_BSWAP
+#ifdef _MSC_VER
+
+// bswap compiler checks copied from https://github.com/google/cityhash/blob/8af9b8c2b889d80c22d6bc26ba0df1afb79a30db/src/city.cc#L50
+// The original code for detecting bswap had the MIT License below.
+//
+// Copyright (c) 2011 Google, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <stdlib.h>
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+
+#elif defined(__APPLE__)
+
+// Mac OS X / Darwin features
+#include <libkern/OSByteOrder.h>
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#elif defined(__sun) || defined(sun)
+
+#include <sys/byteorder.h>
+#define bswap_32(x) BSWAP_32(x)
+#define bswap_64(x) BSWAP_64(x)
+
+#elif defined(__FreeBSD__)
+
+#include <sys/endian.h>
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+
+#elif defined(__OpenBSD__)
+
+#include <sys/types.h>
+#define bswap_32(x) swap32(x)
+#define bswap_64(x) swap64(x)
+
+#elif defined(__NetBSD__)
+
+#include <sys/types.h>
+#include <machine/bswap.h>
+#if defined(__BSWAP_RENAME) && !defined(__bswap_32)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+#endif
+
+#else
+
+#include <byteswap.h>
+
+#endif
+#endif


### PR DESCRIPTION
Use alternative hash for hashing pointers.
The old hash had okay distribution but was slow to compute
(when serializing references/objects/arrays)

Avoid copying pointers from memory when there's no way they would change but the compiler isn't guaranteed that.

Avoid creating inline duplicates of some deinit functions. (TODO: See if default inlining CFLAGS in config.m4 still have an impact on runtime in php7/8)