### PR TITLE
Update php_igbinary.h for php8

### DIFF
--- a/php_igbinary.h
+++ b/php_igbinary.h
@@ -1,7 +1,7 @@
 #ifndef PHPEXT_IGBINARY_BASE_PHP_IGBINARY_H
 #define PHPEXT_IGBINARY_BASE_PHP_IGBINARY_H
 #include "php_version.h"
-#if PHP_MAJOR_VERSION == 7
+#if PHP_MAJOR_VERSION == 7 || PHP_MAJOR_VERSION == 8
 #include "ext/igbinary/src/php7/php_igbinary.h"
 #else
 #error "Unsupported php version for igbinary build"


### PR DESCRIPTION
The following errors occur when compiling igbinary 3.2.1 with php8.0.1 at the same time, but these errors will no longer occur with this change.
```bash
次のファイルから読み込み:  main/internal_functions_cli.c:42:
/home/install_data/subdir/php/ext/igbinary/php_igbinary.h:7:2: エラー: #error "Unsupported php version for igbinary build"
    7 | #error "Unsupported php version for igbinary build"
      |  ^~~~~
make: *** [Makefile:1534: main/internal_functions_cli.lo] エラー 1
```