### PR TITLE
Support GH actions testing in valgrind for php 7.3+

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,10 @@
 *.lo
 *.la
 *.tgz
+*.dep
 .deps
 .libs
-Dockerfile
+Dockerfile*
 Makefile
 Makefile.fragments
 Makefile.global

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,17 @@ jobs:
          # NOTE: If this is not quoted, the yaml parser will convert 7.0 to the number 7,
          # and the docker image `php:7` is the latest minor version of php 7.x (7.4).
          - PHP_VERSION: '7.0'
+           PHP_VERSION_FULL: 7.0.33
          - PHP_VERSION: '7.1'
+           PHP_VERSION_FULL: 7.1.33
          - PHP_VERSION: '7.2'
+           PHP_VERSION_FULL: 7.2.34
          - PHP_VERSION: '7.3'
+           PHP_VERSION_FULL: 7.3.27
          - PHP_VERSION: '7.4'
+           PHP_VERSION_FULL: 7.4.16
          - PHP_VERSION: '8.0'
+           PHP_VERSION_FULL: 8.0.3
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -41,5 +47,14 @@ jobs:
       # Runs a single command using the runners shell
       - name: Build and test in docker
         run: bash ci/test_dockerized.sh ${{ matrix.PHP_VERSION }}
+
+      # We reuse the php base image because
+      # 1. It has any necessary dependencies installed for php 7.0-8.0
+      # 2. It is already downloaded
+      #
+      # We need to install valgrind then rebuild php from source with the configure option '--with-valgrind' to avoid valgrind false positives
+      # because php-src has inline assembly that causes false positives in valgrind when that option isn't used.
+      - name: Build and test in docker again with valgrind
+        run: bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }}
       # NOTE: tests report false positives for zend_string_equals in php 7.3+
       # due to the use of inline assembly in php-src. (not related to igbinary)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.lo
 *.la
 *.tgz
+*.dep
 .deps
 .libs
 Makefile

--- a/ci/Dockerfile.valgrind
+++ b/ci/Dockerfile.valgrind
@@ -1,0 +1,29 @@
+ARG PHP_VERSION
+FROM php:$PHP_VERSION
+WORKDIR /code
+RUN apt-get update && apt-get install -y valgrind && apt-get clean
+
+ADD ci/install_php_custom.sh ci/generate_php_install_dir.sh ci/
+ARG PHP_VERSION_FULL
+ARG PHP_CONFIGURE_ARGS="--disable-all --enable-zts --enable-debug --enable-cgi --enable-session --enable-json"
+ARG PHP_CONFIGURE_ARGS="--disable-all --enable-zts --enable-debug --enable-cgi --enable-session --enable-json"
+ENV PHP_CONFIGURE_ARGS=$PHP_CONFIGURE_ARGS PHP_CUSTOM_VERSION=$PHP_VERSION_FULL
+RUN ci/install_php_custom.sh
+
+# Assume compilation will be the time consuming step.
+# Add tests after compiling so that it's faster to update tests and re-run them locally.
+# (The ability to use custom install directories is useful for running tests locally outside docker)
+# TODO: Reorder
+RUN ln -nsf $(ci/generate_php_install_dir.sh) /php-valgrind-install
+ENV PATH=/php-valgrind-install/bin:$PATH
+
+# Used for running tests in Docker
+# RUN apt-get update && apt-get install -y valgrind && apt-get clean
+# NOTE: In order to avoid valgrind false positives, this would need to compile php from source and configure php --with-valgrind (php-src's zend_string_equals uses inline assembly that causes false positives)
+# - ci/install_php_custom.sh and ci/generate_php_install_dir.sh may be a useful reference for that.
+ADD *.sh *.c *.h *.php *.md config.m4 config.w32 package.xml COPYING CREDITS NEWS igbinary.spec igbinary.php.ini ./
+ADD src ./src
+RUN phpize && ./configure $PHP_CONFIGURE_ARGS && make clean && make -j2
+# RUN docker-php-ext-enable igbinary
+ADD tests ./tests
+ADD ci ./ci

--- a/ci/test_dockerized.sh
+++ b/ci/test_dockerized.sh
@@ -10,9 +10,7 @@ fi
 # -u fail for undefined variables
 set -xeu
 PHP_VERSION=$1
+
 DOCKER_IMAGE=igbinary-$PHP_VERSION-test-runner
 docker build --build-arg="PHP_VERSION=$PHP_VERSION" --tag="$DOCKER_IMAGE" -f ci/Dockerfile .
 docker run --rm $DOCKER_IMAGE ci/test_inner.sh
-# NOTE: php 7.3+ will fail in valgrind because php-src uses custom assembly for its implementation of zend_string_equals
-# In order to fix those false positives, a different set of images would be needed where (1) valgrind was installed before compiling php, and (2) php was compiled with support for valgrind (--with-valgrind) to avoid false positives
-# docker run --rm $DOCKER_IMAGE ci/test_inner_valgrind.sh

--- a/ci/test_dockerized_valgrind.sh
+++ b/ci/test_dockerized_valgrind.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Runs this PECL's unit tests with valgrind and a customizable php build
+# TODO: Support 32-bit builds
+# TODO: Support overridable PHP_CONFIGURE_ARGS
+#
+# We reuse the php base image because
+# 1. It has any necessary dependencies installed for php 7.0-8.0
+# 2. It is already downloaded
+#
+# We need to install valgrind then rebuild php from source with the configure option '--with-valgrind' to avoid valgrind false positives
+# because php-src has inline assembly that causes false positives in valgrind when that option isn't used.
+if [ $# != 2 ]; then
+    echo "Usage: $0 PHP_VERSION PHP_VERSION_FULL" 1>&2
+    echo "e.g. $0 8.0 8.0.3" 1>&2
+    echo "The PHP_VERSION is the version of the php docker image to use" 1>&2
+    echo "The PHP_VERSION_FULL is the version of the php release to download using ci/install_php_custom.sh" 1>&2
+    exit 1
+fi
+# -x Exit immediately if any command fails
+# -e Echo all commands being executed.
+# -u fail for undefined variables
+set -xeu
+PHP_VERSION=$1
+PHP_VERSION_FULL=$2
+
+# NOTE: php 7.3+ will fail in valgrind without "--with-valgrind" because php-src uses custom assembly for its implementation of zend_string_equals
+# In order to fix those false positives, a different set of images would be needed where (1) valgrind was installed before compiling php, and (2) php was compiled with support for valgrind (--with-valgrind) to avoid false positives
+# docker run --rm $DOCKER_IMAGE ci/test_inner_valgrind.sh
+DOCKER_IMAGE_VALGRIND=igbinary-$PHP_VERSION_FULL-valgrind-test-runner
+docker build --build-arg="PHP_VERSION=$PHP_VERSION" --build-arg="PHP_VERSION_FULL=$PHP_VERSION_FULL" --tag="$DOCKER_IMAGE_VALGRIND" -f ci/Dockerfile.valgrind .
+docker run --rm $DOCKER_IMAGE_VALGRIND ci/test_inner_valgrind.sh

--- a/ci/test_inner.sh
+++ b/ci/test_inner.sh
@@ -4,6 +4,9 @@
 # -u fail for undefined variables
 set -xeu
 echo "Run tests in docker"
-REPORT_EXIT_STATUS=1 php ci/run-tests-parallel.php -j$(nproc) -P -q --show-diff
+php --version
+php --ini
+cp ci/run-tests-parallel.php run-tests.php
+REPORT_EXIT_STATUS=1 make test TESTS="-j$(nproc) -P -q --show-diff"
 echo "Test that package.xml is valid"
 pecl package

--- a/ci/test_inner_valgrind.sh
+++ b/ci/test_inner_valgrind.sh
@@ -4,6 +4,9 @@
 # -u fail for undefined variables
 set -xeu
 echo "Run tests in docker"
-REPORT_EXIT_STATUS=1 php ci/run-tests-parallel.php -m -j$(nproc) -P -q --show-diff --show-mem
+php --version
+php --ini
+cp ci/run-tests-parallel.php run-tests.php
+REPORT_EXIT_STATUS=1 make test TESTS="-j$(nproc) -P -q --show-diff -m --show-mem"
 echo "Test that package.xml is valid"
 pecl package


### PR DESCRIPTION
In php 7.3+, zend_string_equals from php-src itself uses inline assembly
which will cause false positives when run in valgrind.