### PR TITLE
Fix build for php 8.1 after changes to enum internals.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,12 +36,12 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.0
+                  PHP_VER: 8.0.7
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.0
+                  PHP_VER: 8.0.7
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x64
@@ -86,22 +86,22 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.3.25
+                  PHP_VER: 7.3.28
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.3.25
+                  PHP_VER: 7.3.28
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.4.13
+                  PHP_VER: 7.4.20
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.4.13
+                  PHP_VER: 7.4.20
                   TS: 0
 
 build_script:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,11 @@ jobs:
          - PHP_VERSION: '7.2'
            PHP_VERSION_FULL: 7.2.34
          - PHP_VERSION: '7.3'
-           PHP_VERSION_FULL: 7.3.27
+           PHP_VERSION_FULL: 7.3.28
          - PHP_VERSION: '7.4'
-           PHP_VERSION_FULL: 7.4.16
+           PHP_VERSION_FULL: 7.4.20
          - PHP_VERSION: '8.0'
-           PHP_VERSION_FULL: 8.0.3
+           PHP_VERSION_FULL: 8.0.7
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/package.xml
+++ b/package.xml
@@ -31,11 +31,11 @@
   <email>tysonandre775@hotmail.com</email>
   <active>yes</active>
  </lead>
- <date>2020-04-18</date>
+ <date>2021-06-05</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.2</release>
-  <api>1.3.0</api>
+  <release>3.2.3dev</release>
+  <api>1.3.1</api>
  </version>
  <stability>
   <release>stable</release>
@@ -43,11 +43,8 @@
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
-* Eliminate impossible/redundant checks.
-* Add a new type code for serialization and unserialization of PHP strings that are larger than 4GB.
-* Add additional checks for overflow when serializing extremely large data structures.
-  (e.g. serializing more than 2**32 strings or 2**32 objects/references/arrays)
-* Support serializing and unserializing php 8.1 enums (can only be unserialized in php 8.1+)
+* Fix build for php 8.1 after changes to enum internals.
+* Update tests to suppress deprecations in php 8.1 and support run-tests.php changes in php 8.1
  </notes>
  <contents>
   <dir name="/">
@@ -224,7 +221,27 @@
  <extsrcrelease />
  <changelog>
   <release>
-   <date>2020-01-11</date>
+   <date>2021-04-18</date>
+   <time>16:00:00</time>
+   <version>
+    <release>3.2.2</release>
+    <api>1.3.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Eliminate impossible/redundant checks.
+* Add a new type code for serialization and unserialization of PHP strings that are larger than 4GB.
+* Add additional checks for overflow when serializing extremely large data structures.
+  (e.g. serializing more than 2**32 strings or 2**32 objects/references/arrays)
+* Support serializing and unserializing php 8.1 enums (can only be unserialized in php 8.1+)
+   </notes>
+  </release>
+  <release>
+   <date>2021-01-11</date>
    <time>16:00:00</time>
    <version>
     <release>3.2.2RC1</release>
@@ -409,7 +426,7 @@
    </notes>
   </release>
   <release>
-   <date>2020-01-11</date>
+   <date>2021-01-11</date>
    <time>16:00:00</time>
    <version>
     <release>3.1.1a1</release>

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2930,7 +2930,7 @@ static int igbinary_unserialize_object_enum_case(struct igbinary_unserialize_dat
 	}
 
 	zend_class_constant *c = Z_PTR_P(zv);
-	if (UNEXPECTED(!(Z_ACCESS_FLAGS(c->value) & ZEND_CLASS_CONST_IS_CASE))) {
+	if (UNEXPECTED(!(ZEND_CLASS_CONST_FLAGS(c) & ZEND_CLASS_CONST_IS_CASE))) {
 		zend_error(E_WARNING, "igbinary_unserialize_object_enum_case: %s::%s is not an enum case", ZSTR_VAL(ce->name), ZSTR_VAL(case_name));
 		zend_string_release(case_name);
 		return 1;

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.2.2"
+#define PHP_IGBINARY_VERSION "3.2.3dev"
 
 /* Macros */
 

--- a/tests/__serialize_003.phpt
+++ b/tests/__serialize_003.phpt
@@ -2,6 +2,9 @@
 __serialize() mechanism (003): Interoperability of different serialization mechanisms
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70400) { echo "skip __serialize/__unserialize not supported in php < 7.4 for compatibility with serialize()"; } ?>
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 

--- a/tests/__serialize_018.phpt
+++ b/tests/__serialize_018.phpt
@@ -2,9 +2,11 @@
 __serialize() freed on unserialize exception without calling destructor.
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70400) { echo "skip __serialize/__unserialize not supported in php < 7.4 for compatibility with serialize()"; } ?>
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
-
 class ThrowsInUnserialize implements Serializable {
     public function serialize() {
         return "test data";

--- a/tests/igbinary_003.phpt
+++ b/tests/igbinary_003.phpt
@@ -1,6 +1,8 @@
 --TEST--
 Check for bool serialisation
---SKIPIF--
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_012.phpt
+++ b/tests/igbinary_012.phpt
@@ -1,6 +1,8 @@
 --TEST--
 Object test
---SKIPIF--
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_021.phpt
+++ b/tests/igbinary_021.phpt
@@ -1,6 +1,8 @@
 --TEST--
 Object Serializable interface
---SKIPIF--
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_031.phpt
+++ b/tests/igbinary_031.phpt
@@ -1,6 +1,8 @@
 --TEST--
 Object Serializable interface throws exceptions
---SKIPIF--
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_047.phpt
+++ b/tests/igbinary_047.phpt
@@ -23,33 +23,35 @@ if (!$array) {
 $output = '';
 
 class S implements SessionHandlerInterface {
-    public function open($path, $name) {
+    public function open($path, $name): bool {
         return true;
     }
 
-    public function close() {
+    public function close(): bool {
         return true;
     }
 
-    public function read($id) {
+    public function read($id): string {
         global $output;
         $output .= "read\n";
         return pack('H*', '0000000214011103666f6f0601');
     }
 
-    public function write($id, $data) {
+    public function write($id, $data): bool {
         global $output;
         $output .= "wrote: ";
         $output .= substr(bin2hex($data), 8). "\n";
         return true;
     }
 
-    public function destroy($id) {
+    public function destroy($id): bool {
         return true;
     }
 
-    public function gc($time) {
-        return true;
+    // > Returns the number of deleted sessions on success, or false on failure.
+    // > Note this value is returned internally to PHP for processing.
+    public function gc($time): int {
+        return 0;
     }
 }
 

--- a/tests/igbinary_052.phpt
+++ b/tests/igbinary_052.phpt
@@ -1,6 +1,8 @@
 --TEST--
 Object Serializable interface can be serialized in references
---SKIPIF--
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_062.phpt
+++ b/tests/igbinary_062.phpt
@@ -1,9 +1,11 @@
 --TEST--
 igbinary should not call __wakeup() if Serializable::unserialize was used to unserialize the object data (like `unserialize`)
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 
-error_reporting(E_ALL);
 class A implements Serializable {
    public $prop = 'value';
    public function serialize() {

--- a/tests/igbinary_073.phpt
+++ b/tests/igbinary_073.phpt
@@ -1,5 +1,8 @@
 --TEST--
 igbinary and large Serializable
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 class Test implements Serializable {

--- a/tests/igbinary_082_php74.phpt
+++ b/tests/igbinary_082_php74.phpt
@@ -2,6 +2,9 @@
 igbinary object with typed properties with reference to ArrayObject
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 70400) die("skip test requires typed properties"); ?>
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 class TestClass {

--- a/tests/igbinary_083.phpt
+++ b/tests/igbinary_083.phpt
@@ -1,5 +1,8 @@
 --TEST--
 igbinary object with reference to ArrayObject
+--INI--
+; Note that php 8.1 deprecates using Serializable without __serialize/__unserialize but we are testing Serialize for igbinary. Suppress deprecations.
+error_reporting=E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 

--- a/tests/igbinary_088.phpt
+++ b/tests/igbinary_088.phpt
@@ -15,7 +15,7 @@ for ($i = 0; $i < 3; $i++) {
 }
 $ser = igbinary_serialize($x);
 $unser = igbinary_unserialize($ser);
-echo urlencode($ser), "\n";
+echo str_replace(['\\', '%'], ['\\\\', '\x'], urlencode($ser)), "\n";
 var_dump($unser);
 
 ?>
@@ -25,7 +25,7 @@ Notice: igbinary_serialize(): "name0" returned as member variable from __sleep()
 Notice: igbinary_serialize(): "name1" returned as member variable from __sleep() but does not exist in %s on line 11
 
 Notice: igbinary_serialize(): "name2" returned as member variable from __sleep() but does not exist in %s on line 11
-%00%00%00%02%17%01X%14%03%11%05name0%00%11%05name1%00%11%05name2%00
+\x00\x00\x00\x02\x17\x01X\x14\x03\x11\x05name0\x00\x11\x05name1\x00\x11\x05name2\x00
 object(X)#2 (3) {
   ["name0"]=>
   NULL

--- a/tests/igbinary_enums_2.phpt
+++ b/tests/igbinary_enums_2.phpt
@@ -18,7 +18,10 @@ enum Suit {
 $arr = ['Hearts' => Suit::Hearts];
 $arr[1] = &$arr['Hearts'];
 $serArray = igbinary_serialize($arr);
-echo urlencode($serArray), "\n";
+// PHP 8.1 added support for %0 as a null byte in EXPECTF in https://github.com/php/php-src/pull/7069
+// Igbinary's use case of urlencode on binary data is rare.
+// So replace % with \x
+echo str_replace(['\\', '%'], ['\\\\', '\x'], urlencode($serArray)), "\n";
 $result = igbinary_unserialize($serArray);
 var_dump($result);
 $result[1] = 'new';
@@ -36,7 +39,7 @@ $serInvalidClass = str_replace('Suit', 'ABCD', $serArray);
 var_dump(igbinary_unserialize($serInvalidClass));
 ?>
 --EXPECTF--
-%00%00%00%02%14%02%11%06Hearts%25%17%04Suit%27%0E%00%06%01%25%22%01
+\x00\x00\x00\x02\x14\x02\x11\x06Hearts\x25\x17\x04Suit\x27\x0E\x00\x06\x01\x25\x22\x01
 array(2) {
   ["Hearts"]=>
   &enum(Suit::Hearts)
@@ -50,14 +53,14 @@ array(2) {
   &string(3) "new"
 }
 
-Warning: igbinary_unserialize_object_enum_case: Suit::HEARTS is not an enum case in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 22
+Warning: igbinary_unserialize_object_enum_case: Suit::HEARTS is not an enum case in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 25
 NULL
 
-Warning: igbinary_unserialize_object_enum_case: Undefined constant Suit::vvvvvv in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 25
+Warning: igbinary_unserialize_object_enum_case: Undefined constant Suit::vvvvvv in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 28
 NULL
 
-Warning: igbinary_unserialize_object_enum_case: Class 'Club' does not exist in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 28
+Warning: igbinary_unserialize_object_enum_case: Class 'Club' does not exist in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 31
 NULL
 
-Warning: igbinary_unserialize_object_enum_case: Class 'ABCD' is not an enum in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 31
+Warning: igbinary_unserialize_object_enum_case: Class 'ABCD' is not an enum in /home/tyson/programming/igbinary/tests/igbinary_enums_2.php on line 34
 NULL


### PR DESCRIPTION
And update tests to suppress deprecations in php 8.1 and support run-tests.php changes in php 8.1

And fix release year in package.xml