### PR TITLE
Release igbinary 3.2.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,12 +36,12 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.1.0alpha3
+                  PHP_VER: 8.1.0beta1
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.1.0alpha3
+                  PHP_VER: 8.1.0beta1
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
            PHP_VERSION_FULL: 7.4.21
          - PHP_VERSION: '8.0'
            PHP_VERSION_FULL: 8.0.8
-         - PHP_VERSION: '8.1.0alpha3'
-           PHP_VERSION_FULL: 8.1.0alpha3
+         - PHP_VERSION: '8.1.0beta1'
+           PHP_VERSION_FULL: 8.1.0beta1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-3.2.4dev
+3.2.4 2021-07-24
 =======
 
 * Forbid serializing classes that deny serialization/unserialization (anonymous classes, CURLFile, etc.) even when subclasses implement '__serialize' and '__unserialize'

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -32,7 +32,7 @@ fi
 
 # Otherwise, put a minimal installation inside of the cache.
 if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.1.0" ] ; then
-	PHP_CUSTOM_VERSION=8.1.0alpha3
+	PHP_CUSTOM_VERSION=8.1.0beta1
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 
 	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"

--- a/ci/run-tests-parallel.php
+++ b/ci/run-tests-parallel.php
@@ -693,7 +693,7 @@ function main()
         $environment['TEST_PHP_EXECUTABLE'] = $php;
     }
 
-    if (strlen($conf_passed)) {
+    if ($conf_passed !== null) {
         if (IS_WINDOWS) {
             $pass_options .= " -c " . escapeshellarg($conf_passed);
         } else {

--- a/package.xml
+++ b/package.xml
@@ -31,10 +31,10 @@ memcached or similar memory based storages for serialized data.</description>
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2021-06-09</date>
+ <date>2021-07-24</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.4dev</release>
+  <release>3.2.4</release>
   <api>1.3.1</api>
  </version>
  <stability>
@@ -204,6 +204,7 @@ memcached or similar memory based storages for serialized data.</description>
     <file name="igbinary_092.phpt" role="test" />
     <file name="igbinary_093.phpt" role="test" />
     <file name="igbinary_094.phpt" role="test" />
+    <file name="igbinary_095.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_enums_1.phpt" role="test" />

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -109,15 +109,16 @@ static zend_always_inline void zval_ptr_dtor_str(zval *zval_ptr)
     return 1;                     \
   }
 
-#if PHP_VERSION_ID >= 70400
-# ifdef ZEND_ACC_NOT_SERIALIZABLE
-#define IGBINARY_IS_NOT_SERIALIZABLE(ce) UNEXPECTED((ce)->ce_flags & (ZEND_ACC_NOT_SERIALIZABLE | ZEND_ACC_ANON_CLASS))
-# else
-#define IGBINARY_IS_NOT_SERIALIZABLE(ce) UNEXPECTED(((ce)->ce_flags & (ZEND_ACC_ANON_CLASS)) || (ce)->serialize == zend_class_serialize_deny)
-# endif
+#ifdef ZEND_ACC_NOT_SERIALIZABLE
+# define IGBINARY_IS_NOT_SERIALIZABLE(ce) UNEXPECTED((ce)->ce_flags & (ZEND_ACC_NOT_SERIALIZABLE | ZEND_ACC_ANON_CLASS))
+# define IGBINARY_IS_NOT_UNSERIALIZABLE(ce) IGBINARY_IS_NOT_SERIALIZABLE(ce)
+#elif PHP_VERSION_ID >= 70400
+# define IGBINARY_IS_NOT_SERIALIZABLE(ce) UNEXPECTED((ce)->serialize == zend_class_serialize_deny)
+# define IGBINARY_IS_NOT_UNSERIALIZABLE(ce) UNEXPECTED((ce)->unserialize == zend_class_unserialize_deny)
 #else
 // Because '__serialize' is not available prior to 7.4, this check is redundant.
-#define IGBINARY_IS_NOT_SERIALIZABLE(ce) (0)
+# define IGBINARY_IS_NOT_SERIALIZABLE(ce) (0)
+# define IGBINARY_IS_NOT_UNSERIALIZABLE(ce) (0)
 #endif
 
 
@@ -2864,7 +2865,7 @@ static ZEND_COLD int igbinary_unserialize_object_ser(struct igbinary_unserialize
 		return 1;
 	}
 
-	if (IGBINARY_IS_NOT_SERIALIZABLE(ce)) {
+	if (IGBINARY_IS_NOT_UNSERIALIZABLE(ce)) {
 		zend_throw_exception_ex(NULL, 0, "Unserialization of '%s' is not allowed", ZSTR_VAL(ce->name));
 		return 1;
 	}
@@ -3053,7 +3054,7 @@ inline static int igbinary_unserialize_object(struct igbinary_unserialize_data *
 		}
 	} while (0);
 
-	if (IGBINARY_IS_NOT_SERIALIZABLE(ce)) {
+	if (IGBINARY_IS_NOT_UNSERIALIZABLE(ce)) {
 		zend_throw_exception_ex(NULL, 0, "Unserialization of '%s' is not allowed", ZSTR_VAL(ce->name));
 		zend_string_release(class_name);
 		return 1;

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.2.3"
+#define PHP_IGBINARY_VERSION "3.2.4"
 
 /* Macros */
 

--- a/tests/igbinary_095.phpt
+++ b/tests/igbinary_095.phpt
@@ -1,0 +1,93 @@
+--TEST--
+Test handling php 8.1 readonly properties
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) { echo "skip readonly properties require php 8.1+\n"; } ?>
+--FILE--
+<?php
+class X {
+    public readonly mixed $var;
+
+    public function __construct(
+        public readonly int $a,
+        private readonly ArrayAccess&Countable $intersection,
+        protected readonly ?string $default = null,
+    ) {
+        $this->var = $intersection;
+    }
+}
+
+class Y {
+    public readonly mixed $var;
+
+    public function __construct(
+        public readonly int $a,
+        private readonly ArrayAccess&Countable $intersection,
+        protected readonly ?string $default = null,
+    ) {
+        $this->var = $intersection;
+    }
+
+    public function __serialize(): array {
+        return [
+            'a' => $this->a,
+            'intersection' => $this->intersection,
+            'default' => $this->default,
+            'var' => $this->var,
+        ];
+    }
+    public function __unserialize(array $data) {
+        [
+            'a' => $this->a,
+            'intersection' => $this->intersection,
+            'default' => $this->default,
+            'var' => $this->var,
+        ] = $data;
+    }
+}
+
+$ser = igbinary_serialize(new X(1, new ArrayObject()));
+echo urlencode($ser), "\n";
+var_dump(igbinary_unserialize($ser));
+$ser = igbinary_serialize(new Y(1, new ArrayObject()));
+echo urlencode($ser), "\n";
+var_dump(igbinary_unserialize($ser));
+?>
+--EXPECT--
+%00%00%00%02%17%01X%14%04%11%03var%17%0BArrayObject%14%04%06%00%06%00%06%01%14%00%06%02%14%00%06%03%00%11%01a%06%01%11%0F%00X%00intersection%22%01%11%0A%00%2A%00default%00
+object(X)#1 (4) {
+  ["var"]=>
+  object(ArrayObject)#2 (1) {
+    ["storage":"ArrayObject":private]=>
+    array(0) {
+    }
+  }
+  ["a"]=>
+  int(1)
+  ["intersection":"X":private]=>
+  object(ArrayObject)#2 (1) {
+    ["storage":"ArrayObject":private]=>
+    array(0) {
+    }
+  }
+  ["default":protected]=>
+  NULL
+}
+%00%00%00%02%17%01Y%14%04%11%01a%06%01%11%0Cintersection%17%0BArrayObject%14%04%06%00%06%00%06%01%14%00%06%02%14%00%06%03%00%11%07default%00%11%03var%22%01
+object(Y)#1 (4) {
+  ["var"]=>
+  object(ArrayObject)#2 (1) {
+    ["storage":"ArrayObject":private]=>
+    array(0) {
+    }
+  }
+  ["a"]=>
+  int(1)
+  ["intersection":"Y":private]=>
+  object(ArrayObject)#2 (1) {
+    ["storage":"ArrayObject":private]=>
+    array(0) {
+    }
+  }
+  ["default":protected]=>
+  NULL
+}


### PR DESCRIPTION
Add test of serializing/unserializing readonly properties

Forbid serialization of classes which forbid serialization even when
subclasses or anonymous classes implement `__serialize` and
`__unserialize`

Test in 8.1.0beta1