### PR TITLE
Fix array pointer in php 7.2 after array optimization

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,22 +36,22 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.1.0beta1
+                  PHP_VER: 8.1.0beta2
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.1.0beta1
+                  PHP_VER: 8.1.0beta2
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.8
+                  PHP_VER: 8.0.9
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.8
+                  PHP_VER: 8.0.9
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x64
@@ -106,12 +106,12 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.4.21
+                  PHP_VER: 7.4.22
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.4.21
+                  PHP_VER: 7.4.22
                   TS: 0
 
 build_script:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,11 +36,11 @@ jobs:
          - PHP_VERSION: '7.3'
            PHP_VERSION_FULL: 7.3.29
          - PHP_VERSION: '7.4'
-           PHP_VERSION_FULL: 7.4.21
+           PHP_VERSION_FULL: 7.4.22
          - PHP_VERSION: '8.0'
-           PHP_VERSION_FULL: 8.0.8
-         - PHP_VERSION: '8.1.0beta1'
-           PHP_VERSION_FULL: 8.1.0beta1
+           PHP_VERSION_FULL: 8.0.9
+         - PHP_VERSION: '8.1.0beta2'
+           PHP_VERSION_FULL: 8.1.0beta2
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -32,7 +32,7 @@ fi
 
 # Otherwise, put a minimal installation inside of the cache.
 if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.1.0" ] ; then
-	PHP_CUSTOM_VERSION=8.1.0beta1
+	PHP_CUSTOM_VERSION=8.1.0beta2
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 
 	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"

--- a/src/php7/igbinary_zend_hash.h
+++ b/src/php7/igbinary_zend_hash.h
@@ -231,6 +231,12 @@ static zend_always_inline zval *igbinary_zend_hash_add_or_find(HashTable *ht, ze
 add_to_hash:
 	idx = ht->nNumUsed++;
 	ht->nNumOfElements++;
+#if PHP_VERSION_ID < 70300
+	if (ht->nInternalPointer == HT_INVALID_IDX) {
+		ht->nInternalPointer = idx;
+	}
+	zend_hash_iterators_update(ht, HT_INVALID_IDX, idx);
+#endif
 	arData = ht->arData;
 	p = arData + idx;
 	p->key = key;
@@ -316,6 +322,12 @@ convert_to_hash:
 	}
 add:
 	ht->nNumOfElements++;
+#if PHP_VERSION_ID < 70300
+	if (ht->nInternalPointer == HT_INVALID_IDX) {
+		ht->nInternalPointer = ht->nNumUsed - 1;
+	}
+	zend_hash_iterators_update(ht, HT_INVALID_IDX, ht->nNumUsed - 1);
+#endif
 	p->h = h;
 	p->key = NULL;
 	ZVAL_NULL(&p->val);

--- a/tests/igbinary_096.phpt
+++ b/tests/igbinary_096.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test unserialization creates valid current()
+--INI--
+display_errors=stderr
+error_reporting=E_ALL
+--FILE--
+<?php
+$arr = [
+	'one' => [
+		'two' => [
+			'three' => [
+				'four'
+			],
+		],
+	],
+];
+$test = current(current(current(current($arr))));
+
+var_dump($test);
+
+// Note: after unserialization the current is the last array element.
+$arr2 = igbinary_unserialize(igbinary_serialize($arr));
+$test2 = current(current(current(current($arr2))));
+
+var_dump($test2);
+?>
+--EXPECT--
+string(4) "four"
+string(4) "four"


### PR DESCRIPTION
Fixes #338

In php 7.3, appending to an array stopped changing the internal array
pointer if it was uninitialized
(initializing an array avoided creating HT_INVALID_IDX).
Igbinary was copying an API similar to that of 7.3 without
adapting it for 7.2.