### PR TITLE
Use interned strings when unserializing in keys/class names in php 8.1+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
          - PHP_VERSION: '8.0'
            PHP_VERSION_FULL: 8.0.12
          - PHP_VERSION: '8.1.0RC6'
-           PHP_VERSION_FULL: 8.1.0RC6
+           PHP_VERSION_FULL: 8.1.0
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ igbinary
 ========
 
 [![Build Status](https://github.com/igbinary/igbinary/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/igbinary/igbinary/actions/workflows/main.yml?query=branch%3Amaster)
-[![Build Status](https://travis-ci.org/igbinary/igbinary.svg?branch=v3)](https://travis-ci.org/igbinary/igbinary)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/suhkkumj1yh9dgan?svg=true)](https://ci.appveyor.com/project/TysonAndre/igbinary-bemsx)
 
 Igbinary is a drop in replacement for the standard php serializer.

--- a/benchmark/serialize-arrayarray.b.php
+++ b/benchmark/serialize-arrayarray.b.php
@@ -4,26 +4,28 @@
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-array-array');
-
 class Obj {
 	private $foo = 10;
 	public $bar = "test";
 	public $i;
 }
 
-$array = array();
-$inner_array = array(array());
-for ($i = 0; $i < 1000; $i++) {
-    $array[] = $inner_array;
-}
+call_user_func(function () {
+    $b = new Bench('serialize-array-array');
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 2000; $j++) {
-		$ser = igbinary_serialize($array);
-		$unser = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    $array = array();
+    $inner_array = array(array());
+    for ($i = 0; $i < 1000; $i++) {
+        $array[] = $inner_array;
+    }
+
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 2000; $j++) {
+            $ser = igbinary_serialize($array);
+            $unser = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/serialize-objectarray.b.php
+++ b/benchmark/serialize-objectarray.b.php
@@ -4,27 +4,29 @@
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-object-array');
-
 class Obj {
 	private $foo = 10;
 	public $bar = "test";
 	public $i;
 }
 
-$array = array();
-for ($i = 0; $i < 1000; $i++) {
-	$o = new Obj();
-	$o->i = $i;
+call_user_func(function () {
+    $b = new Bench('serialize-object-array');
 
-	$array[] = $o;
-}
+    $array = array();
+    for ($i = 0; $i < 1000; $i++) {
+        $o = new Obj();
+        $o->i = $i;
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 2000; $j++) {
-		$ser = igbinary_serialize($array);
-	}
-	$b->stop($j);
-	$b->write();
-}
+        $array[] = $o;
+    }
+
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 2000; $j++) {
+            $ser = igbinary_serialize($array);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/serialize-scalar-int.b.php
+++ b/benchmark/serialize-scalar-int.b.php
@@ -4,15 +4,17 @@
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-scalar-int');
+call_user_func(function () {
+    $b = new Bench('serialize-scalar-int');
 
-$var = 1;
+    $var = 1;
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 3500000; $j++) {
-		$ser = igbinary_serialize($var);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 3500000; $j++) {
+            $ser = igbinary_serialize($var);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/serialize-scalararray.b.php
+++ b/benchmark/serialize-scalararray.b.php
@@ -4,31 +4,33 @@
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-scalar-array');
+call_user_func(function () {
+    $b = new Bench('serialize-scalar-array');
 
-$array = array();
-for ($i = 0; $i < 1000; $i++) {
-	switch ($i % 4) {
-	case 0:
-		$array[] = "da string " . $i;
-		break;
-	case 1:
-		$array[] = 1.31 * $i;
-		break;
-	case 2:
-		$array[] = rand(0, PHP_INT_MAX);
-		break;
-	case 3:
-		$array[] = (bool)($i & 1);
-		break;
-	}
-}
+    $array = array();
+    for ($i = 0; $i < 1000; $i++) {
+        switch ($i % 4) {
+        case 0:
+            $array[] = "da string " . $i;
+            break;
+        case 1:
+            $array[] = 1.31 * $i;
+            break;
+        case 2:
+            $array[] = rand(0, PHP_INT_MAX);
+            break;
+        case 3:
+            $array[] = (bool)($i & 1);
+            break;
+        }
+    }
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 12000; $j++) {
-		$ser = igbinary_serialize($array);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 12000; $j++) {
+            $ser = igbinary_serialize($array);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/serialize-stringarray.b.php
+++ b/benchmark/serialize-stringarray.b.php
@@ -4,15 +4,17 @@
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-string-array');
+call_user_func(function () {
+    $b = new Bench('serialize-string-array');
 
-$array = unserialize(file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'l10n-en.ser'));
+    $array = unserialize(file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'l10n-en.ser'));
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 360; $j++) {
-		$ser = igbinary_serialize($array);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 360; $j++) {
+            $ser = igbinary_serialize($array);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-arrayarray.php
+++ b/benchmark/unserialize-arrayarray.php
@@ -4,25 +4,27 @@
 
 require_once 'bench.php';
 
-$b = new Bench('unserialize-arrayarray');
+call_user_func(function () {
+    $b = new Bench('unserialize-arrayarray');
 
-srand(13333);
-$data = [];
-for ($i = 0; $i < 1000; $i++) {
-    $part = [];
-    for ($j = 0; $j < rand() % 20; $j++) {
-        $part[] = rand() % 300;
+    srand(13333);
+    $data = [];
+    for ($i = 0; $i < 1000; $i++) {
+        $part = [];
+        for ($j = 0; $j < rand() % 20; $j++) {
+            $part[] = rand() % 300;
+        }
+        $data[] = $part;
     }
-    $data[] = $part;
-}
-$ser = igbinary_serialize($data);
+    $ser = igbinary_serialize($data);
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 500; $j++) {
-		$array = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-    unset($array);
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 500; $j++) {
+            $array = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+        unset($array);
+    }
+});

--- a/benchmark/unserialize-emptyarray.php
+++ b/benchmark/unserialize-emptyarray.php
@@ -6,16 +6,18 @@
 
 require_once 'bench.php';
 
-$b = new Bench('unserialize-emptyarray');
+call_user_func(function () {
+    $b = new Bench('unserialize-emptyarray');
 
-$ser = igbinary_serialize([]);
+    $ser = igbinary_serialize([]);
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	$results = [];
-	for ($j = 0; $j < 500000; $j++) {
-		$results[] = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        $results = [];
+        for ($j = 0; $j < 500000; $j++) {
+            $results[] = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-intarray.b.php
+++ b/benchmark/unserialize-intarray.b.php
@@ -6,19 +6,21 @@
 
 require_once 'bench.php';
 
-$b = new Bench('unserialize-intarray');
+call_user_func(function () {
+    $b = new Bench('unserialize-intarray');
 
-$array = array();
-for ($i = 0; $i < 256; $i++) {
-	$array[] = $i;
-}
-$ser = igbinary_serialize($array);
+    $array = array();
+    for ($i = 0; $i < 256; $i++) {
+        $array[] = $i;
+    }
+    $ser = igbinary_serialize($array);
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 50000; $j++) {
-		$array = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 50000; $j++) {
+            $array = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-largearrayarray.php
+++ b/benchmark/unserialize-largearrayarray.php
@@ -4,25 +4,27 @@
 
 require_once 'bench.php';
 
-$b = new Bench('unserialize-largearrayarray');
+call_user_func(function () {
+    $b = new Bench('unserialize-largearrayarray');
 
-srand(13333);
-$data = [];
-for ($i = 0; $i < 1000; $i++) {
-    $part = [];
-    for ($j = 0, $n = rand() % 100; $j < $n; $j++) {
-        $part[] = rand() % 300;
+    srand(13333);
+    $data = [];
+    for ($i = 0; $i < 1000; $i++) {
+        $part = [];
+        for ($j = 0, $n = rand() % 100; $j < $n; $j++) {
+            $part[] = rand() % 300;
+        }
+        $data[] = $part;
     }
-    $data[] = $part;
-}
-$ser = igbinary_serialize($data);
+    $ser = igbinary_serialize($data);
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 500; $j++) {
-		$array = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-    unset($array);
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 500; $j++) {
+            $array = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+        unset($array);
+    }
+});

--- a/benchmark/unserialize-object.b.php
+++ b/benchmark/unserialize-object.b.php
@@ -1,0 +1,28 @@
+<?php
+
+// Description: Unserialize object array
+
+require_once 'bench.php';
+
+class Obj {
+	private $foo = 10;
+	public $bar = "test";
+	public $i;
+}
+
+call_user_func(function () {
+    $b = new Bench('unserialize-object');
+
+    $o = new Obj();
+    $o->i = 2;
+    $ser = igbinary_serialize($o);
+
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 300000; $j++) {
+            $o2 = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-objectarray.totalmem.php
+++ b/benchmark/unserialize-objectarray.totalmem.php
@@ -4,29 +4,31 @@
 
 require_once 'bench.php';
 
-$b = new Bench('unserialize-object-array');
-
 class Obj {
 	private $foo = 10;
 	public $bar = "test";
 	public $i;
 }
 
-$array = array();
-for ($i = 0; $i < 1000; $i++) {
-	$o = new Obj();
-	$o->i = $i;
+call_user_func(function () {
+    $b = new Bench('unserialize-object-array');
 
-	$array[] = $o;
-}
-$ser = igbinary_serialize($array);
+    $array = array();
+    for ($i = 0; $i < 1000; $i++) {
+        $o = new Obj();
+        $o->i = $i;
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	$arrays = [];
-	for ($j = 0; $j < 200; $j++) {
-		$arrays[] = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+        $array[] = $o;
+    }
+    $ser = igbinary_serialize($array);
+
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        $arrays = [];
+        for ($j = 0; $j < 200; $j++) {
+            $arrays[] = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-scalar-int.b.php
+++ b/benchmark/unserialize-scalar-int.b.php
@@ -4,15 +4,17 @@
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-scalar-int');
+call_user_func(function () {
+    $b = new Bench('serialize-scalar-int');
 
-$ser = igbinary_serialize(1);
+    $ser = igbinary_serialize(1);
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 3600000; $j++) {
-		$var = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 3600000; $j++) {
+            $var = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-scalararray.b.php
+++ b/benchmark/unserialize-scalararray.b.php
@@ -4,32 +4,34 @@
 
 require_once 'bench.php';
 
-$b = new Bench('unserialize-scalar-array');
+call_user_func(function () {
+    $b = new Bench('unserialize-scalar-array');
 
-$array = array();
-for ($i = 0; $i < 1000; $i++) {
-	switch ($i % 4) {
-	case 0:
-		$array[] = "da string " . $i;
-		break;
-	case 1:
-		$array[] = 1.31 * $i;
-		break;
-	case 2:
-		$array[] = rand(0, PHP_INT_MAX);
-		break;
-	case 3:
-		$array[] = (bool)($i & 1);
-		break;
-	}
-}
-$ser = igbinary_serialize($array);
+    $array = array();
+    for ($i = 0; $i < 1000; $i++) {
+        switch ($i % 4) {
+        case 0:
+            $array[] = "da string " . $i;
+            break;
+        case 1:
+            $array[] = 1.31 * $i;
+            break;
+        case 2:
+            $array[] = rand(0, PHP_INT_MAX);
+            break;
+        case 3:
+            $array[] = (bool)($i & 1);
+            break;
+        }
+    }
+    $ser = igbinary_serialize($array);
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 5800; $j++) {
-		$array = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 5800; $j++) {
+            $array = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-stdclass.b.php
+++ b/benchmark/unserialize-stdclass.b.php
@@ -1,26 +1,28 @@
 <?php
 
-// Description: Serialize stdClass with dynamic values
+// Description: Unserialize stdClass with dynamic values
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-stdclass');
+call_user_func(function () {
+    $b = new Bench('unserialize-stdclass');
 
-$array = [];
-for ($i = 0; $i < 1000; $i++) {
-	$o = new stdClass();
-	$o->foo = 10;
-	$o->i = $i;
-	$o->isOdd = $i % 2 != 0;
-	$array[] = $o;
-}
-$ser = igbinary_serialize($array);
+    $array = [];
+    for ($i = 0; $i < 1000; $i++) {
+        $o = new stdClass();
+        $o->foo = 10;
+        $o->i = $i;
+        $o->isOdd = $i % 2 != 0;
+        $array[] = $o;
+    }
+    $ser = igbinary_serialize($array);
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 2000; $j++) {
-		$data = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 2000; $j++) {
+            $data = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-stringarray.b.php
+++ b/benchmark/unserialize-stringarray.b.php
@@ -4,15 +4,17 @@
 
 require_once 'bench.php';
 
-$b = new Bench('serialize-string-array');
+call_user_func(function () {
+    $b = new Bench('unserialize-string-array');
 
-$ser = igbinary_serialize(unserialize(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'l10n-en.ser')));
+    $ser = igbinary_serialize(unserialize(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'l10n-en.ser')));
 
-for ($i = 0; $i < 40; $i++) {
-	$b->start();
-	for ($j = 0; $j < 500; $j++) {
-		$array = igbinary_unserialize($ser);
-	}
-	$b->stop($j);
-	$b->write();
-}
+    for ($i = 0; $i < 40; $i++) {
+        $b->start();
+        for ($j = 0; $j < 500; $j++) {
+            $array = igbinary_unserialize($ser);
+        }
+        $b->stop($j);
+        $b->write();
+    }
+});

--- a/benchmark/unserialize-structured-array.b.php
+++ b/benchmark/unserialize-structured-array.b.php
@@ -1,30 +1,21 @@
 <?php
 
-// Description: Unserialize object array
+// Description: Unserialize structured array
 
 require_once 'bench.php';
 
-class Obj {
-	private $foo = 10;
-	public $bar = "test";
-	public $i;
-}
-
 call_user_func(function () {
-    $b = new Bench('unserialize-object-array');
+    $b = new Bench('unserialize-structured-array');
 
-    $array = array();
+    $array = [];
     for ($i = 0; $i < 1000; $i++) {
-        $o = new Obj();
-        $o->i = $i;
-
-        $array[] = $o;
+        $array[] = ['key' => "da string $i", 'flag' => $i % 2];
     }
     $ser = igbinary_serialize($array);
 
     for ($i = 0; $i < 40; $i++) {
         $b->start();
-        for ($j = 0; $j < 540; $j++) {
+        for ($j = 0; $j < 5800; $j++) {
             $array = igbinary_unserialize($ser);
         }
         $b->stop($j);

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -30,19 +30,10 @@ if [ "x${TRAVIS:-0}" != "x" ]; then
     rm -rf $HOME/travis_cache/
 fi
 
-# Otherwise, put a minimal installation inside of the cache.
-if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.1.0" ] ; then
-	PHP_CUSTOM_VERSION=8.1.0beta2
-	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
+PHP_FOLDER="php-$PHP_CUSTOM_NORMAL_VERSION"
 
-	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-	PHP_TAR_URL=https://downloads.php.net/~ramsey/$PHP_TAR_FILE
-else
-	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
-
-	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-	PHP_TAR_URL=https://secure.php.net/distributions/$PHP_TAR_FILE
-fi
+PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
+PHP_TAR_URL=https://secure.php.net/distributions/$PHP_TAR_FILE
 if [ ! -f $PHP_TAR_FILE ]; then
 	curl --location --verbose $PHP_TAR_URL -o $PHP_TAR_FILE
 fi

--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,10 @@ memcached or similar memory based storages for serialized data.</description>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
 * Update test expectation for php 8.2.0-dev.
+* In php 8.1+, make igbinary_unserialize check to see if an equivalent interned string already exists when unserializing object property names, array keys, and class names
+  and use that instead of creating a brand new string.
+  (This deliberately doesn't create a new interned string if one doesn't already exist.)
+  (Before this change, igbinary would deduplicate strings when serializing, but would not check if strings were interned by PHP itself when unserializing)
  </notes>
  <contents>
   <dir name="/">

--- a/src/php7/hash_si.c
+++ b/src/php7/hash_si.c
@@ -68,6 +68,7 @@ void hash_si_deinit(struct hash_si *h) {
 /* }}} */
 /* {{{ get_key_hash */
 inline static uint32_t get_key_hash(zend_string *key_zstr) {
+	/* Fetch the hash, computing and storing it in key_zstr if it was not computed before. */
 	uint32_t key_hash = ZSTR_HASH(key_zstr);
 #if SIZEOF_ZEND_LONG > 4
 	if (UNEXPECTED(key_hash == 0)) {
@@ -120,9 +121,12 @@ inline static void hash_si_rehash(struct hash_si *h) {
 	efree(old_data);
 }
 /* }}} */
+/* {{{ hash_si_find_or_insert */
 /**
  * If the string key already exists in the map, return the associated value.
  * If it doesn't exist, indicate that to the caller.
+ *
+ * This is used in igbinary_serialize to deduplicate strings.
  */
 struct hash_si_result hash_si_find_or_insert(struct hash_si *h, zend_string *key_zstr, uint32_t value) {
 	struct hash_si_result result;

--- a/tests/igbinary_022.phpt
+++ b/tests/igbinary_022.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Object test, unserialize_callback_func (PHP < 8.2)
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 80200) echo "skip requires php < 8.2\n"; ?>
+<?php if (PHP_VERSION_ID >= 80200) echo "skip requires php < 8.2\n"; ?>
 --INI--
 error_reporting=E_ALL
 unserialize_callback_func=autoload


### PR DESCRIPTION
In php 8.1, Use interned strings if they already exist for object property names,
array keys, class names, and `enum` case names.

Something similar is already done by php for unserialize.

Fix unserialize_callback_func SKIPIF condition.

Update benchmark title.

Run benchmarks outside top-level scope due to opcache being much better at
inferring types for and optimizing code in function scopes.