### PR TITLE
Fix debug warning for unserializing circular array reference

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -48,6 +48,7 @@ memcached or similar memory based storages for serialized data.</description>
   and use that instead of creating a brand new string.
   (This deliberately doesn't create a new interned string if one doesn't already exist.)
   (Before this change, igbinary would deduplicate strings when serializing, but would not check if strings were interned by PHP itself when unserializing)
+* Avoid debug build assertion failure for `HT_ASSERT_RC1` the same way as PHP's unserialize - this is a case where ostensibly there are no other references to the array being unserialized.
  </notes>
  <contents>
   <dir name="/">
@@ -210,6 +211,7 @@ memcached or similar memory based storages for serialized data.</description>
     <file name="igbinary_094.phpt" role="test" />
     <file name="igbinary_095.phpt" role="test" />
     <file name="igbinary_096.phpt" role="test" />
+    <file name="igbinary_097.phpt" role="test" />
     <file name="igbinary_bug54662.phpt" role="test" />
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_enums_1.phpt" role="test" />

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2562,6 +2562,12 @@ inline static int igbinary_unserialize_array(struct igbinary_unserialize_data *i
 	}
 	array_init_size(z_deref, n);
 	h = Z_ARRVAL_P(z_deref);
+#if PHP_VERSION_ID >= 70200
+	/* The array may contain references to itself, in which case we'll be modifying an
+	 * rc>1 array. This is okay, since the array is, ostensibly, only visible to
+	 * unserialize (in practice unserialization handlers also see it). */
+	HT_ALLOW_COW_VIOLATION(h);
+#endif
 	if (create_ref) {
 		/* Only create a reference if this is not from __unserialize(), because the existence of __unserialize can change */
 		struct igbinary_value_ref ref;

--- a/tests/igbinary_097.phpt
+++ b/tests/igbinary_097.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test serialize globals
+--SKIPIF--
+<?php
+if (!extension_loaded("igbinary")) print "skip\n";
+if (PHP_VERSION_ID >= 80100) print "skip php < 8.1\n"; // https://wiki.php.net/rfc/restrict_globals_usage
+?>
+--FILE--
+<?php
+call_user_func(function () {
+    foreach ($GLOBALS as $key => $_) {
+        if ($key !== 'GLOBALS') {
+            unset($GLOBALS[$key]);
+        }
+    }
+    $ser = igbinary_serialize($GLOBALS);
+    echo urlencode($ser) . "\n";
+    var_dump(igbinary_unserialize($ser));
+    $GLOBALS['globalVar'] = new stdClass();
+    $ser = igbinary_serialize($GLOBALS);
+    echo urlencode($ser) . "\n";
+    var_dump(igbinary_unserialize($ser));
+});
+--EXPECTF--
+%00%00%00%02%14%01%11%07GLOBALS%14%01%0E%00%01%01
+array(1) {
+  ["GLOBALS"]=>
+  array(1) {
+    ["GLOBALS"]=>
+    *RECURSION*
+  }
+}
+%00%00%00%02%14%02%11%07GLOBALS%14%02%0E%00%01%01%11%09globalVar%17%08stdClass%14%00%0E%01%22%02
+array(2) {
+  ["GLOBALS"]=>
+  array(2) {
+    ["GLOBALS"]=>
+    *RECURSION*
+    ["globalVar"]=>
+    object(stdClass)#3 (0) {
+    }
+  }
+  ["globalVar"]=>
+  object(stdClass)#3 (0) {
+  }
+}


### PR DESCRIPTION
Allow arrays unserialized by igbinary to have circular references

https://wiki.php.net/rfc/restrict_globals_usage means the test doesn't
work in php 8.1

Closes #308