### PR TITLE
Reduce excessive gcc inlining, add other optimizations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,22 +36,22 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.1.1
+                  PHP_VER: 8.1.3
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.1.1
+                  PHP_VER: 8.1.3
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.14
+                  PHP_VER: 8.0.16
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.14
+                  PHP_VER: 8.0.16
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x64
@@ -111,7 +111,7 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.4.27
+                  PHP_VER: 7.4.28
                   TS: 0
 
 build_script:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,11 +36,11 @@ jobs:
          - PHP_VERSION: '7.3'
            PHP_VERSION_FULL: 7.3.32
          - PHP_VERSION: '7.4'
-           PHP_VERSION_FULL: 7.4.27
+           PHP_VERSION_FULL: 7.4.28
          - PHP_VERSION: '8.0'
-           PHP_VERSION_FULL: 8.0.14
+           PHP_VERSION_FULL: 8.0.16
          - PHP_VERSION: '8.1'
-           PHP_VERSION_FULL: 8.1.1
+           PHP_VERSION_FULL: 8.1.3
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+3.2.8dev 2022-??-??
+=======
+
+* Reduce excessive inlining to reduce shared library size.
+* Miscellaneous optimizations.
+
 3.2.7 2022-01-12
 =======
 

--- a/config.m4
+++ b/config.m4
@@ -61,7 +61,7 @@ if test "$PHP_IGBINARY" != "no"; then
   elif test "$GCC" = yes; then
     AC_MSG_RESULT(gcc)
     if test -z "`echo $CFLAGS | grep -- '-O[0123]'`"; then
-      PHP_IGBINARY_CFLAGS="$CFLAGS -O2 -Wall -Wpointer-arith -Wcast-align -Wwrite-strings -Wswitch -finline-limit=10000 --param large-function-growth=10000 --param inline-unit-growth=10000"
+      PHP_IGBINARY_CFLAGS="$CFLAGS -O2 -Wall -Wpointer-arith -Wcast-align -Wwrite-strings -Wswitch"
     fi
   elif test "$ICC" = yes; then
     AC_MSG_RESULT(icc)

--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,7 @@ memcached or similar memory based storages for serialized data.</description>
  <date>2022-01-12</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.7</release>
+  <release>3.2.8dev</release>
   <api>1.3.1</api>
  </version>
  <stability>
@@ -43,12 +43,8 @@ memcached or similar memory based storages for serialized data.</description>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
-* Update test expectations for php 8.2.0-dev. Add `#[AllowDynamicProperties]` Attribute to some tests to avoid notices.
-* In php 8.1+, make igbinary_unserialize check to see if an equivalent interned string already exists when unserializing object property names, array keys, and class names
-  and use that instead of creating a brand new string.
-  (This deliberately doesn't create a new interned string if one doesn't already exist.)
-  (Before this change, igbinary would deduplicate strings when serializing, but would not check if strings were interned by PHP itself when unserializing)
-* Avoid debug build assertion failure for `HT_ASSERT_RC1` the same way as PHP's unserialize - this is a case where ostensibly there are no other references to the array being unserialized.
+* Reduce excessive inlining to reduce shared library size.
+* Miscellaneous optimizations.
  </notes>
  <contents>
   <dir name="/">
@@ -234,6 +230,27 @@ memcached or similar memory based storages for serialized data.</description>
  <providesextension>igbinary</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2021-08-11</date>
+   <time>16:00:00</time>
+   <version>
+    <release>3.2.7</release>
+    <api>1.3.1</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Update test expectations for php 8.2.0-dev. Add `#[AllowDynamicProperties]` Attribute to some tests to avoid notices.
+* In php 8.1+, make igbinary_unserialize check to see if an equivalent interned string already exists when unserializing object property names, array keys, and class names
+  and use that instead of creating a brand new string.
+  (This deliberately doesn't create a new interned string if one doesn't already exist.)
+  (Before this change, igbinary would deduplicate strings when serializing, but would not check if strings were interned by PHP itself when unserializing)
+* Avoid debug build assertion failure for `HT_ASSERT_RC1` the same way as PHP's unserialize - this is a case where ostensibly there are no other references to the array being unserialized.
+   </notes>
+  </release>
   <release>
    <date>2021-08-11</date>
    <time>16:00:00</time>

--- a/src/php7/hash.h
+++ b/src/php7/hash.h
@@ -123,12 +123,16 @@ void hash_si_traverse (struct hash_si *h, int (*traverse_function) (const char *
  * @param h Pointer to hash_si struct.
  * @return Size of hash_si.
  */
-size_t hash_si_size(struct hash_si *h);
+static zend_always_inline size_t hash_si_size(struct hash_si *h) {
+	return h->used;
+}
 
 /** Returns capacity of hash_si.
  * @param h Pointer to hash_si struct.
  * @return Capacity of hash_si.
  */
-size_t hash_si_capacity(struct hash_si *h);
+static zend_always_inline size_t hash_si_capacity(struct hash_si *h) {
+	return h->mask + 1;
+}
 
 #endif /* HASH_H */

--- a/src/php7/hash_ptr.h
+++ b/src/php7/hash_ptr.h
@@ -86,7 +86,9 @@ int hash_si_ptr_find (struct hash_si_ptr *h, const zend_uintptr_t key, uint32_t 
  * @param h Pointer to hash_si_ptr struct.
  * @return Size of hash_si_ptr.
  */
-size_t hash_si_ptr_size(struct hash_si_ptr *h);
+static zend_always_inline size_t hash_si_ptr_size(struct hash_si_ptr *h) {
+	return h->used;
+}
 
 /**
  * If the key does not exist, add a mapping from key to value and returns SIZE_MAX
@@ -103,6 +105,8 @@ size_t hash_si_ptr_find_or_insert(struct hash_si_ptr *h, const zend_uintptr_t ke
  * @param h Pointer to hash_si_ptr struct.
  * @return Capacity of hash_si_ptr.
  */
-size_t hash_si_ptr_capacity(struct hash_si_ptr *h);
+zend_always_inline static size_t hash_si_ptr_capacity(struct hash_si_ptr *h) {
+	return h->size;
+}
 
 #endif /* HASH_PTR_H */

--- a/src/php7/hash_si_ptr.c
+++ b/src/php7/hash_si_ptr.c
@@ -78,10 +78,6 @@ int hash_si_ptr_init(struct hash_si_ptr *h, size_t size) {
  */
 void hash_si_ptr_deinit(struct hash_si_ptr *h) {
 	efree(h->data);
-	h->data = NULL;
-
-	h->size = 0;
-	h->used = 0;
 }
 /* }}} */
 /* {{{ hash_si_ptr_rehash */
@@ -153,7 +149,7 @@ size_t hash_si_ptr_find_or_insert(struct hash_si_ptr *h, const zend_uintptr_t ke
 			h->used++;
 
 			/* The size increased, so check if we need to expand the map */
-			if ((h->size >> 1) < h->used) {
+			if (UNEXPECTED((h->size >> 1) < h->used)) {
 				hash_si_ptr_rehash(h);
 			}
 			return SIZE_MAX;
@@ -164,28 +160,6 @@ size_t hash_si_ptr_find_or_insert(struct hash_si_ptr *h, const zend_uintptr_t ke
 		/* linear prob */
 		hv = (hv + 1) & mask;
 	}
-}
-/* }}} */
-/* {{{ hash_si_ptr_size */
-/**
- * @param h the hash map from pointers to integers.
- * @return the number of elements in this hash map.
- */
-size_t hash_si_ptr_size(struct hash_si_ptr *h) {
-	assert(h != NULL);
-
-	return h->used;
-}
-/* }}} */
-/* {{{ hash_si_ptr_capacity */
-/**
- * @param h the hash map from pointers to integers.
- * @return the capacity of this hash map.
- */
-size_t hash_si_ptr_capacity(struct hash_si_ptr *h) {
-	assert(h != NULL);
-
-	return h->size;
 }
 /* }}} */
 

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.2.7"
+#define PHP_IGBINARY_VERSION "3.2.8dev"
 
 /* Macros */
 


### PR DESCRIPTION
Closes #357

benchmark/comparisons.php didn't show a difference after taking out the
CFLAGS overrides and was slightly improved with other optimizations.

This reduces gcc compilation size with `export CFLAGS=-O3` from 193960 to 74736
(size will vary with platform/gcc version).
Note that `-g` will add a lot more to the size for debugging symbols in
an unused(cold) region of the shared library.