### PR TITLE
Throw Errors or emit deprecation notices for dynamic properties

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,12 +56,12 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.22
+                  PHP_VER: 8.0.24
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.22
+                  PHP_VER: 8.0.24
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,9 @@ jobs:
          - PHP_VERSION: '8.1'
            PHP_VERSION_FULL: 8.1.11
          - PHP_VERSION: '8.2.0RC3'
-           PHP_VERSION_FULL: 8.2.0RC3
+           PHP_VERSION_FULL: 8.2.0RC4
          - PHP_VERSION: '8.2.0RC3'
-           PHP_VERSION_FULL: 8.2.0RC3
+           PHP_VERSION_FULL: 8.2.0RC4
            DOCKER_ARCHITECTURE: i386
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -36,7 +36,7 @@ if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.2.0" ] ; then
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 
 	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-	PHP_TAR_URL=https://downloads.php.net/~pierrick/$PHP_TAR_FILE
+	PHP_TAR_URL=https://downloads.php.net/~sergey/$PHP_TAR_FILE
 else
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -32,7 +32,7 @@ fi
 
 # Otherwise, put a minimal installation inside of the cache.
 if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.2.0" ] ; then
-	PHP_CUSTOM_VERSION=8.2.0RC3
+	PHP_CUSTOM_VERSION=8.2.0RC4
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 
 	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"

--- a/package.xml
+++ b/package.xml
@@ -45,6 +45,11 @@ memcached or similar memory based storages for serialized data.</description>
  <notes>
 * Reduce excessive inlining to reduce shared library size.
 * Miscellaneous optimizations.
+* Update test expectations to handle changes to var_export output (fully qualified class names) in PHP 8.2.
+* Throw an Error when igbinary_unserialize would add dynamic properties to class definitions that forbid them in PHP 8.0+
+  (especially PHP 8.2 `readonly` classes)
+* Emit a deprecation notice when igbinary_unserialize() adds dynamic properties to a class without `#[AllowDynamicProperties]` in PHP 8.2.
+  Doing that would become an Error in PHP 9.0.
  </notes>
  <contents>
   <dir name="/">

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2841,8 +2841,8 @@ inline static int igbinary_unserialize_object_properties(struct igbinary_unseria
 			if (UNEXPECTED(!(ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
 				php_error_docref(NULL, E_DEPRECATED, "Creation of dynamic property %s::$%s is deprecated",
 					ZSTR_VAL(ce->name), zend_get_unmangled_property_name(key_str));
-				zend_string_release(key_str);
 				if (UNEXPECTED(EG(exception))) {
+					zend_string_release(key_str);
 					return 1;
 				}
 			}

--- a/tests/__serialize_012.phpt
+++ b/tests/__serialize_012.phpt
@@ -4,9 +4,10 @@ Test unserialization of classes derived from ArrayIterator
 <?php if (PHP_VERSION_ID < 70406) { echo "Skip requires php 7.4.6+"; } ?>
 --FILE--
 <?php
-// TODO remove temporary workaround for __PHP_Incomplete_Class missing #[AllowDynamicProperties]
-if (PHP_VERSION_ID >= 80200) { require_once __DIR__ . '/php82_suppress_dynamic_properties_warning.inc'; }
 // based on bug45706.phpt from php-src
+//
+// NOTE: ArrayIterator::__debugInfo adds a fake private property that doesn't actually exist, which affects var_dump.
+// This isn't a bug in the unserializer.
 class Foo1 extends ArrayIterator
 {
 }

--- a/tests/__serialize_012.phpt
+++ b/tests/__serialize_012.phpt
@@ -4,6 +4,8 @@ Test unserialization of classes derived from ArrayIterator
 <?php if (PHP_VERSION_ID < 70406) { echo "Skip requires php 7.4.6+"; } ?>
 --FILE--
 <?php
+// TODO remove temporary workaround for __PHP_Incomplete_Class missing #[AllowDynamicProperties]
+if (PHP_VERSION_ID >= 80200) { require_once __DIR__ . '/php82_suppress_dynamic_properties_warning.inc'; }
 // based on bug45706.phpt from php-src
 class Foo1 extends ArrayIterator
 {

--- a/tests/__serialize_022.phpt
+++ b/tests/__serialize_022.phpt
@@ -4,7 +4,7 @@ __serialize() mechanism (021): Test __serialize without __unserialize
 <?php if (PHP_VERSION_ID < 70400) { echo "skip __serialize/__unserialize not supported in php < 7.4 for compatibility with serialize()"; } ?>
 --FILE--
 <?php
-
+#[AllowDynamicProperties]
 class Test {
     const SOME_CONST = ['key' => 'value'];
 

--- a/tests/igbinary_020.phpt
+++ b/tests/igbinary_020.phpt
@@ -7,6 +7,11 @@ if(!extension_loaded('igbinary')) {
 	dl('igbinary.' . PHP_SHLIB_SUFFIX);
 }
 
+if (PHP_VERSION_ID >= 80200) {
+    // TODO undo workaround when #[AllowDynamicProperties] is added to __PHP_Incomplete_Class
+    error_reporting(E_ALL & ~E_DEPRECATED);
+}
+
 function test($type, $variable, $test) {
 	$serialized = pack('H*', $variable);
 	$unserialized = igbinary_unserialize($serialized);

--- a/tests/igbinary_022_php82.phpt
+++ b/tests/igbinary_022_php82.phpt
@@ -10,8 +10,6 @@ unserialize_callback_func=autoload
 if(!extension_loaded('igbinary')) {
 	dl('igbinary.' . PHP_SHLIB_SUFFIX);
 }
-// TODO remove temporary workaround for __PHP_Incomplete_Class missing #[AllowDynamicProperties]
-if (PHP_VERSION_ID >= 80200) { require_once __DIR__ . '/php82_suppress_dynamic_properties_warning.inc'; }
 
 function test(string $type, string $variable) {
 	$serialized = pack('H*', $variable);
@@ -79,7 +77,7 @@ int(2)
 OK
 Autoloading Obk
 
-Warning: igbinary_unserialize(): Function autoload() hasn't defined the class it was called for in %sigbinary_022_php82.php on line 11
+Warning: igbinary_unserialize(): Function autoload() hasn't defined the class it was called for in %sigbinary_022_php82.php on line 9
 autoload
 17034f626b140211016106011101620602
 object(__PHP_Incomplete_Class)#1 (3) {
@@ -91,10 +89,10 @@ object(__PHP_Incomplete_Class)#1 (3) {
   int(2)
 }
 
-Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 23
+Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 21
 NULL
 
-Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 24
+Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 22
 ERROR
 missing_autoload
 Caught Invalid callback missing_autoload, function "missing_autoload" not found or invalid function name

--- a/tests/igbinary_022_php82.phpt
+++ b/tests/igbinary_022_php82.phpt
@@ -10,6 +10,8 @@ unserialize_callback_func=autoload
 if(!extension_loaded('igbinary')) {
 	dl('igbinary.' . PHP_SHLIB_SUFFIX);
 }
+// TODO remove temporary workaround for __PHP_Incomplete_Class missing #[AllowDynamicProperties]
+if (PHP_VERSION_ID >= 80200) { require_once __DIR__ . '/php82_suppress_dynamic_properties_warning.inc'; }
 
 function test(string $type, string $variable) {
 	$serialized = pack('H*', $variable);
@@ -77,7 +79,7 @@ int(2)
 OK
 Autoloading Obk
 
-Warning: igbinary_unserialize(): Function autoload() hasn't defined the class it was called for in %sigbinary_022_php82.php on line 9
+Warning: igbinary_unserialize(): Function autoload() hasn't defined the class it was called for in %sigbinary_022_php82.php on line 11
 autoload
 17034f626b140211016106011101620602
 object(__PHP_Incomplete_Class)#1 (3) {
@@ -89,10 +91,10 @@ object(__PHP_Incomplete_Class)#1 (3) {
   int(2)
 }
 
-Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 21
+Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 23
 NULL
 
-Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 22
+Warning: test(): The script tried to access a property on an incomplete object. Please ensure that the class definition "Obk" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in %sigbinary_022_php82.php on line 24
 ERROR
 missing_autoload
 Caught Invalid callback missing_autoload, function "missing_autoload" not found or invalid function name

--- a/tests/igbinary_072.phpt
+++ b/tests/igbinary_072.phpt
@@ -2,7 +2,8 @@
 igbinary and __PHP_INCOMPLETE_CLASS
 --FILE--
 <?php
-#[AllowDynamicProperties]
+// TODO: Remove temporary workaround for __PHP_Incomplete_Class missing #[AllowDynamicProperties]
+if (PHP_VERSION_ID >= 80200) { require_once __DIR__ . '/php82_suppress_dynamic_properties_warning.inc'; }
 class Test {}
 function test_ser_unser($obj) {
     var_dump(bin2hex($s = igbinary_serialize($obj)));

--- a/tests/igbinary_097.phpt
+++ b/tests/igbinary_097.phpt
@@ -3,7 +3,7 @@ Test serialize globals
 --SKIPIF--
 <?php
 if (!extension_loaded("igbinary")) print "skip\n";
-if (PHP_VERSION_ID >= 80100) print "skip php < 8.1\n"; // https://wiki.php.net/rfc/restrict_globals_usage
+if (PHP_VERSION_ID >= 80100) print "skip php >= 8.1\n"; // https://wiki.php.net/rfc/restrict_globals_usage
 ?>
 --FILE--
 <?php

--- a/tests/igbinary_098.phpt
+++ b/tests/igbinary_098.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test PHP 8.2 readonly classes
+--SKIPIF--
+<?php
+if (!extension_loaded("igbinary")) print "skip\n";
+if (PHP_VERSION_ID < 80200) print "skip php < 8.2\n";
+?>
+--FILE--
+<?php
+readonly class C {
+    public int $a;
+    public static function create() {
+        $c = new C();
+        $c->a = 8;
+        return $c;
+    }
+}
+$c = new C();
+$ser = igbinary_serialize($c);
+echo urlencode($ser), "\n";
+var_dump(igbinary_unserialize($ser));
+$c = C::create();
+$ser = igbinary_serialize($c);
+echo urlencode($ser), "\n";
+var_dump(igbinary_unserialize($ser));
+$invalid1 = str_replace('a', 'b', $ser);
+try {
+    var_dump(igbinary_unserialize($invalid1));
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+--EXPECT--
+%00%00%00%02%17%01C%14%01%00
+object(C)#2 (0) {
+  ["a"]=>
+  uninitialized(int)
+}
+%00%00%00%02%17%01C%14%01%11%01a%06%08
+object(C)#1 (1) {
+  ["a"]=>
+  int(8)
+}
+Error: Cannot create dynamic property C::$b in igbinary_unserialize

--- a/tests/igbinary_099.phpt
+++ b/tests/igbinary_099.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test PHP 8.2 deprecation of creation of dynamic properties
+--SKIPIF--
+<?php
+if (!extension_loaded("igbinary")) print "skip\n";
+if (PHP_VERSION_ID < 80200) print "skip php < 8.2\n";
+?>
+--FILE--
+<?php
+class C {
+}
+
+$c = new C();
+$invalidValues = [
+    "\x00\x00\x00\x02\x17\x01C\x14\x01\x11\x01a\x06\x08",
+    "\x00\x00\x00\x02\x17\x01C\x14\x01\x11\x04\x00*\x00a\x06\x08",
+];
+foreach ($invalidValues as $invalid) {
+    try {
+        var_dump(igbinary_unserialize($invalid));
+    } catch (Error $e) {
+        printf("%s: %s\n", $e::class, $e->getMessage());
+    }
+}
+--EXPECTF--
+Deprecated: igbinary_unserialize(): Creation of dynamic property C::$a is deprecated in %sigbinary_099.php on line 12
+object(C)#2 (1) {
+  ["a"]=>
+  int(8)
+}
+
+Deprecated: igbinary_unserialize(): Creation of dynamic property C::$a is deprecated in %sigbinary_099.php on line 12
+object(C)#2 (1) {
+  ["a":protected]=>
+  int(8)
+}

--- a/tests/php82_suppress_dynamic_properties_warning.inc
+++ b/tests/php82_suppress_dynamic_properties_warning.inc
@@ -4,7 +4,7 @@ if (PHP_VERSION_ID < 80200) {
 }
 $totalErrors = 0;
 function igbinary_suppress_dynamic_properties_warning($errno, $errstr): bool {
-    if ($errno === E_DEPRECATED && str_starts_with($errstr, 'Creation of dynamic property') > 0) {
+    if ($errno === E_DEPRECATED && str_contains($errstr, 'Creation of dynamic property')) {
         $GLOBALS['totalErrors']++;
         return true;
     }


### PR DESCRIPTION
PHP 8.2 deprecated dynamic properties by default and added `readonly`
classes which forbidded dynamic properties.

Update release notes.
Temporarily work around `__PHP_Incomplete_Class` missing
`#[AllowDynamicProperties]`

Related to https://github.com/php/php-src/issues/9325 - the final approach/implementation should be similar to what PHP ends up using  in unserialize()