### PR TITLE
3.2.8, Build dlls in GitHub actions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,12 +36,12 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.2.0RC3
+                  PHP_VER: 8.2.0RC4
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.2.0RC3
+                  PHP_VER: 8.2.0RC4
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86

--- a/.github/workflows/build_dlls.yml
+++ b/.github/workflows/build_dlls.yml
@@ -1,0 +1,62 @@
+name: Build DLLs
+# Based on https://github.com/TysonAndre/var_representation/blob/main/.github/workflows/build_dlls.yml
+# which is based on https://github.com/krakjoe/apcu/blob/migbinaryer/.github/workflows/config.yml
+# Builds DLLs for 64-bit php.
+# See https://windows.php.net/ - At this time, the windows PHP team no longer has access to the machine used to build dlls.
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+  release:
+    types: [published]
+
+jobs:
+  windows:
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      matrix:
+          version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
+          arch: [x64]
+          ts: [nts, ts]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout igbinary
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        id: setup-php
+        uses: cmb69/setup-php-sdk@v0.6
+        with:
+          version: ${{matrix.version}}
+          arch: ${{matrix.arch}}
+          ts: ${{matrix.ts}}
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.arch}}
+          toolset: ${{steps.setup-php.outputs.toolset}}
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: configure --enable-igbinary --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
+      - name: make
+        run: nmake
+      # Run tests, failing if they fail. REPORT_EXIT_STATUS=1 is the default for tests in php 7.2+
+      - name: test
+        run: nmake test TESTS="--show-diff tests"
+      - name: package
+        run: |
+          md .install
+          copy LICENSE README.md .install
+          if exist x64 (
+            if exist x64\Release (set prefix=x64\Release) else set prefix=x64\Release_TS
+          ) else (
+            if exist Release (set prefix=Release) else set prefix=Release_TS
+          )
+          copy %prefix%\php_igbinary.dll .install
+          copy %prefix%\php_igbinary.pdb .install
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: igbinary-${{github.ref}}-Windows-php-${{matrix.version}}-${{matrix.arch}}-${{matrix.ts}}
+          path: .install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,9 @@ jobs:
            DOCKER_ARCHITECTURE: i386
          - PHP_VERSION: '8.1'
            PHP_VERSION_FULL: 8.1.11
-         - PHP_VERSION: '8.2.0RC3'
+         - PHP_VERSION: '8.2.0RC4'
            PHP_VERSION_FULL: 8.2.0RC4
-         - PHP_VERSION: '8.2.0RC3'
+         - PHP_VERSION: '8.2.0RC4'
            PHP_VERSION_FULL: 8.2.0RC4
            DOCKER_ARCHITECTURE: i386
 

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,9 @@
-3.2.8dev 2022-??-??
+3.2.8 2022-10-16
 =======
 
 * Reduce excessive inlining to reduce shared library size.
 * Miscellaneous optimizations.
+* Set up CI job to build dlls on https://github.com/igbinary/igbinary - at the moment, the infrastructure used by the Windows for php team has been broken for months.
 
 3.2.7 2022-01-12
 =======

--- a/package.xml
+++ b/package.xml
@@ -31,10 +31,10 @@ memcached or similar memory based storages for serialized data.</description>
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-01-12</date>
+ <date>2022-10-16</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.8dev</release>
+  <release>3.2.8</release>
   <api>1.3.1</api>
  </version>
  <stability>
@@ -50,6 +50,7 @@ memcached or similar memory based storages for serialized data.</description>
   (especially PHP 8.2 `readonly` classes)
 * Emit a deprecation notice when igbinary_unserialize() adds dynamic properties to a class without `#[AllowDynamicProperties]` in PHP 8.2.
   Doing that would become an Error in PHP 9.0.
+* Set up CI job to build dlls on https://github.com/igbinary/igbinary - at the moment, the infrastructure used by the Windows for php team has been broken for months.
  </notes>
  <contents>
   <dir name="/">

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.2.8dev"
+#define PHP_IGBINARY_VERSION "3.2.8"
 
 /* Macros */
 


### PR DESCRIPTION
The test failure is spurious `001+ Can't initialize heap: [0x000001e7] Attempt to access invalid address` and a known unrelated bug in 32-bit PHP for windows - that bug has an open PR