### PR TITLE
Fix bug preventing unserializing representation of strings > 4GB, add macro to detect igbinary data header

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -34,8 +34,8 @@ memcached or similar memory based storages for serialized data.</description>
  <date>2022-10-17</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.9</release>
-  <api>1.3.1</api>
+  <release>3.2.10-dev</release>
+  <api>1.4.0</api>
  </version>
  <stability>
   <release>stable</release>
@@ -43,7 +43,7 @@ memcached or similar memory based storages for serialized data.</description>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
-* Fix invalid release artifact name in job to build dlls for https://github.com/igbinary/igbinary
+* Add a macro that callers can use to check if igbinary will accept the header for data being unserialized.
  </notes>
  <contents>
   <dir name="/">
@@ -229,6 +229,22 @@ memcached or similar memory based storages for serialized data.</description>
  <providesextension>igbinary</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-10-17</date>
+   <time>16:00:00</time>
+   <version>
+    <release>3.2.9</release>
+    <api>1.3.1</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Fix invalid release artifact name in job to build dlls for https://github.com/igbinary/igbinary
+   </notes>
+  </release>
   <release>
    <date>2022-10-16</date>
    <time>16:00:00</time>

--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,7 @@ memcached or similar memory based storages for serialized data.</description>
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-10-19</date>
+ <date>2022-11-06</date>
  <time>16:00:00</time>
  <version>
   <release>3.2.10</release>

--- a/package.xml
+++ b/package.xml
@@ -31,10 +31,10 @@ memcached or similar memory based storages for serialized data.</description>
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-10-17</date>
+ <date>2022-10-19</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.10-dev</release>
+  <release>3.2.10</release>
   <api>1.4.0</api>
  </version>
  <stability>
@@ -44,6 +44,7 @@ memcached or similar memory based storages for serialized data.</description>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
 * Add a macro that callers can use to check if igbinary will accept the header for data being unserialized.
+* Fix bug preventing the unserialization of data containing representations of strings larger than 4GB.
  </notes>
  <contents>
   <dir name="/">
@@ -199,6 +200,7 @@ memcached or similar memory based storages for serialized data.</description>
     <file name="igbinary_087.phpt" role="test" />
     <file name="igbinary_088.phpt" role="test" />
     <file name="igbinary_089.phpt" role="test" />
+    <file name="igbinary_089_32bit.phpt" role="test" />
     <file name="igbinary_090.phpt" role="test" />
     <file name="igbinary_091.phpt" role="test" />
     <file name="igbinary_092.phpt" role="test" />

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2161,7 +2161,7 @@ inline static int igbinary_unserialize_header(struct igbinary_unserialize_data *
 	version = igbinary_unserialize32(igsd);
 
 	/* Support older version 1 and the current format 2 */
-	if (version == IGBINARY_FORMAT_VERSION || version == 0x00000001) {
+	if (EXPECTED(version == IGBINARY_FORMAT_VERSION || version == 0x00000001)) {
 		return 0;
 	} else {
 		igbinary_unserialize_header_emit_warning(igsd, version);

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2345,7 +2345,8 @@ inline static zend_string *igbinary_unserialize_string(struct igbinary_unseriali
 /* }}} */
 /* igbinary_unserialize_extremely_long_chararray {{{ */
 static ZEND_COLD zend_never_inline zend_string* igbinary_unserialize_extremely_long_chararray(struct igbinary_unserialize_data *igsd) {
-#if SIZEOF_ZEND_LONG > 4
+#if SIZEOF_SIZE_T <= 4
+	(void)igsd;
 	zend_error(E_WARNING, "igbinary_unserialize_chararray: cannot unserialize 64-bit data on 32-bit platform");
 	return NULL;
 #else

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.2.10-dev"
+#define PHP_IGBINARY_VERSION "3.2.10"
 
 /* Macros */
 

--- a/tests/igbinary_089.phpt
+++ b/tests/igbinary_089.phpt
@@ -2,12 +2,14 @@
 Test serializing string > 4G
 --INI--
 memory_limit=15G
+display_errors=stderr
+error_reporting=E_ALL
 --CONFLICTS--
 high_memory
 --SKIPIF--
 <?php
 if (!extension_loaded("igbinary")) print "skip\n";
-if (PHP_INT_SIZE <= 4) { print "skip requires 74-bit\n"; }
+if (PHP_INT_SIZE <= 4) { print "skip requires 64-bit\n"; }
 if (!getenv('IGBINARY_HIGH_MEMORY_TESTS')) { print "skip requires IGBINARY_HIGH_MEMORY_TESTS=1\n"; }
 ?>
 --FILE--
@@ -19,9 +21,13 @@ echo bin2hex(substr($ser, 0, 20)) . "\n";
 $unser = igbinary_unserialize($ser);
 unset($ser);
 var_dump($unser === str_repeat('*', 4200000000));
+$ser_invalid = hex2bin('0000000213fa56ea002a');
+var_dump(igbinary_unserialize($ser_invalid));
 
 ?>
 --EXPECTF--
 len=4200000009
 0000000213fa56ea002a2a2a2a2a2a2a2a2a2a2a
 bool(true)
+Warning: igbinary_unserialize_chararray: end-of-data in %sigbinary_089.php on line 10
+NULL

--- a/tests/igbinary_089_32bit.phpt
+++ b/tests/igbinary_089_32bit.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test unserializing invalid 64-bit string header on 32-bit platform
+--INI--
+display_errors=stderr
+error_reporting=E_ALL
+--CONFLICTS--
+high_memory
+--SKIPIF--
+<?php
+if (!extension_loaded("igbinary")) print "skip\n";
+if (PHP_INT_SIZE > 4) { print "skip requires 32-bit\n"; }
+?>
+--FILE--
+<?php
+$ser_invalid = hex2bin('0000000213fa56ea002a');
+var_dump(igbinary_unserialize($ser_invalid));
+
+?>
+--EXPECTF--
+Warning: igbinary_unserialize_chararray: end-of-data in %sigbinary_089_32bit.php on line 3
+NULL

--- a/tests/igbinary_089_32bit.phpt
+++ b/tests/igbinary_089_32bit.phpt
@@ -17,5 +17,5 @@ var_dump(igbinary_unserialize($ser_invalid));
 
 ?>
 --EXPECTF--
-Warning: igbinary_unserialize_chararray: end-of-data in %sigbinary_089_32bit.php on line 3
+Warning: igbinary_unserialize_chararray: %s in %sigbinary_089_32bit.php on line 3
 NULL


### PR DESCRIPTION
And add a macro that callers can use to check for igbinary header

`IGBINARY_HIGH_MEMORY_TESTS=1 make test TESTS=tests/igbinary_089.phpt\ --show-diff` passes locally