### PR TITLE
Fix #371 - lookup of pointer for typed property info is slow

### DIFF
--- a/.github/workflows/build_dlls.yml
+++ b/.github/workflows/build_dlls.yml
@@ -1,6 +1,6 @@
 name: Build DLLs
 # Based on https://github.com/TysonAndre/var_representation/blob/main/.github/workflows/build_dlls.yml
-# which is based on https://github.com/krakjoe/apcu/blob/migbinaryer/.github/workflows/config.yml
+# which is based on https://github.com/krakjoe/apcu/blob/master/.github/workflows/config.yml
 # Builds DLLs for 64-bit php.
 # See https://windows.php.net/ - At this time, the windows PHP team no longer has access to the machine used to build dlls.
 

--- a/package.xml
+++ b/package.xml
@@ -31,10 +31,10 @@ memcached or similar memory based storages for serialized data.</description>
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-11-07</date>
+ <date>2022-02-02</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.12</release>
+  <release>3.2.13</release>
   <api>1.4.0</api>
  </version>
  <stability>
@@ -43,7 +43,7 @@ memcached or similar memory based storages for serialized data.</description>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
-* Fix symbol error seen in php 8.2.0 loading zend_class_unserialize_deny, due to failing to load a header defining a macro.
+* Speed up unserialization of typed properties by reducing hash table collisions when looking up property reference info.
  </notes>
  <contents>
   <dir name="/">
@@ -239,6 +239,22 @@ memcached or similar memory based storages for serialized data.</description>
  <providesextension>igbinary</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-11-07</date>
+   <time>16:00:00</time>
+   <version>
+    <release>3.2.12</release>
+    <api>1.4.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Fix symbol error seen in php 8.2.0 loading zend_class_unserialize_deny, due to failing to load a header defining a macro.
+   </notes>
+  </release>
   <release>
    <date>2022-11-06</date>
    <time>16:00:00</time>

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -2845,7 +2845,7 @@ inline static int igbinary_unserialize_object_properties(struct igbinary_unseria
 					if (igsd->ref_props) {
 						/* Remove old entry from ref_props table, if it exists. */
 						zend_hash_index_del(
-							igsd->ref_props, (zend_uintptr_t) prototype_value);
+							igsd->ref_props, ((zend_uintptr_t) prototype_value) >> ZEND_MM_ALIGNMENT_LOG2);
 					}
 				}
 #endif
@@ -2927,7 +2927,7 @@ inline static int igbinary_unserialize_object_properties(struct igbinary_unseria
 					zend_hash_init(igsd->ref_props, 8, NULL, NULL, 0);
 				}
 				zend_hash_index_update_ptr(
-					igsd->ref_props, (zend_uintptr_t) vp, info);
+					igsd->ref_props, ((zend_uintptr_t) vp) >> ZEND_MM_ALIGNMENT_LOG2, info);
 			}
 		}
 #endif
@@ -3459,7 +3459,7 @@ static int igbinary_unserialize_zval(struct igbinary_unserialize_data *igsd, zva
 #if PHP_VERSION_ID >= 70400
 				zend_property_info *info = NULL;
 				if (igsd->ref_props) {
-					info = zend_hash_index_find_ptr(igsd->ref_props, (zend_uintptr_t) z);
+					info = zend_hash_index_find_ptr(igsd->ref_props, ((zend_uintptr_t) z) >> ZEND_MM_ALIGNMENT_LOG2);
 				}
 #endif
 				ZVAL_NEW_REF(z, z);

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.2.12"
+#define PHP_IGBINARY_VERSION "3.2.13"
 
 /* Macros */
 


### PR DESCRIPTION
Pointers are aligned to at least 8 bits on 64-bit systems (usually more), so there are long chains of hash collisions when inserting and looking up in ref_props.