### PR TITLE
Fix bug in igbinary_unserialize_object_enum_case...

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,32 +35,42 @@ environment:
         matrix:
                 - ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.2.0RC5
+                  PHP_VER: 8.3.0beta1
                   TS: 1
                   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                 - ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.2.0RC5
+                  PHP_VER: 8.3.0beta1
                   TS: 0
                   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                 - ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.1.11
+                  PHP_VER: 8.2.8
                   TS: 1
                   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                 - ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.1.11
+                  PHP_VER: 8.2.8
                   TS: 0
                   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                 - ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.24
+                  PHP_VER: 8.1.21
                   TS: 1
                   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                 - ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.24
+                  PHP_VER: 8.1.21
+                  TS: 0
+                  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                - ARCH: x86
+                  VC: vs16
+                  PHP_VER: 8.0.29
+                  TS: 1
+                  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                - ARCH: x64
+                  VC: vs16
+                  PHP_VER: 8.0.29
                   TS: 0
                   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                 - ARCH: x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,8 @@ jobs:
          - PHP_VERSION: '8.2'
            PHP_VERSION_FULL: 8.2.8
            DOCKER_ARCHITECTURE: i386
+         - PHP_VERSION: '8.3.0beta1'
+           PHP_VERSION_FULL: 8.3.0beta1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -66,7 +68,8 @@ jobs:
       #
       # We need to install valgrind then rebuild php from source with the configure option '--with-valgrind' to avoid valgrind false positives
       # because php-src has inline assembly that causes false positives in valgrind when that option isn't used.
+      # The OS release in the PHP 7.0 image is too old to install valgrind without workarounds: https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found
       - name: Build and test in docker again with valgrind
-        run: bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}
+        run: if [[ ${{ matrix.PHP_VERSION }} != '7.0' ]]; then bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}; fi
       # NOTE: tests report false positives for zend_string_equals in php 7.3+
       # due to the use of inline assembly in php-src. (not related to igbinary)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,16 @@ jobs:
          - PHP_VERSION: '7.4'
            PHP_VERSION_FULL: 7.4.30
          - PHP_VERSION: '8.0'
-           PHP_VERSION_FULL: 8.0.22
+           PHP_VERSION_FULL: 8.0.29
          - PHP_VERSION: '8.0'
-           PHP_VERSION_FULL: 8.0.22
+           PHP_VERSION_FULL: 8.0.29
            DOCKER_ARCHITECTURE: i386
          - PHP_VERSION: '8.1'
-           PHP_VERSION_FULL: 8.1.11
-         - PHP_VERSION: '8.2.0RC5'
-           PHP_VERSION_FULL: 8.2.0RC5
-         - PHP_VERSION: '8.2.0RC5'
-           PHP_VERSION_FULL: 8.2.0RC5
+           PHP_VERSION_FULL: 8.1.21
+         - PHP_VERSION: '8.2'
+           PHP_VERSION_FULL: 8.2.8
+         - PHP_VERSION: '8.2'
+           PHP_VERSION_FULL: 8.2.8
            DOCKER_ARCHITECTURE: i386
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -31,12 +31,12 @@ if [ "x${TRAVIS:-0}" != "x" ]; then
 fi
 
 # Otherwise, put a minimal installation inside of the cache.
-if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.2.0" ] ; then
-	PHP_CUSTOM_VERSION=8.2.0RC4
+if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.3.0" ] ; then
+	PHP_CUSTOM_VERSION=8.3.0beta1
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 
 	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-	PHP_TAR_URL=https://downloads.php.net/~sergey/$PHP_TAR_FILE
+	PHP_TAR_URL=https://downloads.php.net/~eric/$PHP_TAR_FILE
 else
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 

--- a/ci/run-tests-parallel.php
+++ b/ci/run-tests-parallel.php
@@ -2787,10 +2787,10 @@ case "$1" in
     gdb --args {$cmd}
     ;;
 "valgrind")
-    USE_ZEND_ALLOC=0 valgrind $2 ${cmd}
+    USE_ZEND_ALLOC=0 valgrind $2 {$cmd}
     ;;
 "rr")
-    rr record $2 ${cmd}
+    rr record $2 {$cmd}
     ;;
 *)
     {$cmd}

--- a/ci/test_dockerized_valgrind.sh
+++ b/ci/test_dockerized_valgrind.sh
@@ -27,7 +27,7 @@ ARCHITECTURE=${3:-}
 # In order to fix those false positives, a different set of images would be needed where (1) valgrind was installed before compiling php, and (2) php was compiled with support for valgrind (--with-valgrind) to avoid false positives
 # docker run --rm $DOCKER_IMAGE ci/test_inner_valgrind.sh
 CFLAGS="-DZEND_RC_DEBUG=1"
-PHP_CONFIGURE_ARGS="--disable-all --enable-zts --enable-debug --enable-cgi --enable-session --enable-json --with-curl"
+PHP_CONFIGURE_ARGS="--disable-all --enable-zts --enable-debug --enable-cgi --enable-session --enable-json"
 if [[ "$ARCHITECTURE" == i386 ]]; then
 	PHP_IMAGE="$ARCHITECTURE/php"
 	DOCKER_IMAGE_VALGRIND="igbinary-valgrind-test-runner:$ARCHITECTURE-$PHP_VERSION_FULL"

--- a/package.xml
+++ b/package.xml
@@ -31,10 +31,10 @@ memcached or similar memory based storages for serialized data.</description>
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2023-02-26</date>
+ <date>2023-08-01</date>
  <time>16:00:00</time>
  <version>
-  <release>3.2.14</release>
+  <release>3.2.15dev</release>
   <api>1.4.0</api>
  </version>
  <stability>
@@ -43,8 +43,7 @@ memcached or similar memory based storages for serialized data.</description>
  </stability>
  <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
  <notes>
-* Fix build error in PHP 8.3-dev
-* Fix test expectation errors in php 8.3-dev due to change to php's TypeErrors.
+* Fix crash in igbinary_unserialize_object_enum_case with opcache protected memory and non-constant value.
  </notes>
  <contents>
   <dir name="/">
@@ -216,6 +215,7 @@ memcached or similar memory based storages for serialized data.</description>
     <file name="igbinary_bug72134.phpt" role="test" />
     <file name="igbinary_enums_1.phpt" role="test" />
     <file name="igbinary_enums_2.phpt" role="test" />
+    <file name="igbinary_enums_3.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />
     <file name="php82_suppress_dynamic_properties_warning.inc" role="test" />
     <file name="sleep_mangled_name_clash.phpt" role="test" />
@@ -240,6 +240,25 @@ memcached or similar memory based storages for serialized data.</description>
  <providesextension>igbinary</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2023-02-26</date>
+   <time>16:00:00</time>
+   <version>
+    <release>3.2.14</release>
+    <api>1.4.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/igbinary/igbinary/blob/master/COPYING">BSD-3-Clause</license>
+   <notes>
+* Fix crash in igbinary_unserialize_object_enum_case with opcache protected memory and non-constant value. (#380)
+  `igbinary_serialize()` now modifies the temporary copy used by the php process
+  instead of the shared immutable copy in memcached, the same way as php
+  `serialize()`
+ </notes>
+  </release>
   <release>
    <date>2023-02-02</date>
    <time>16:00:00</time>

--- a/package.xml
+++ b/package.xml
@@ -216,6 +216,7 @@ memcached or similar memory based storages for serialized data.</description>
     <file name="igbinary_enums_1.phpt" role="test" />
     <file name="igbinary_enums_2.phpt" role="test" />
     <file name="igbinary_enums_3.phpt" role="test" />
+    <file name="igbinary_enums_3_php83.phpt" role="test" />
     <file name="igbinary_unserialize_v1_compatible.phpt" role="test" />
     <file name="php82_suppress_dynamic_properties_warning.inc" role="test" />
     <file name="sleep_mangled_name_clash.phpt" role="test" />

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -3031,7 +3031,7 @@ static int igbinary_unserialize_object_enum_case(struct igbinary_unserialize_dat
 		return 1;
 	}
 
-	zval *zv = zend_hash_find(&ce->constants_table, case_name);
+	zval *zv = zend_hash_find(CE_CONSTANTS_TABLE(ce), case_name);
 	if (UNEXPECTED(!zv)) {
 		zend_error(E_WARNING, "igbinary_unserialize_object_enum_case: Undefined constant %s::%s", ZSTR_VAL(ce->name), ZSTR_VAL(case_name));
 		zend_string_release(case_name);

--- a/src/php7/igbinary.h
+++ b/src/php7/igbinary.h
@@ -18,7 +18,7 @@ struct zval;
 /** Binary protocol version of igbinary. */
 #define IGBINARY_FORMAT_VERSION 0x00000002
 
-#define PHP_IGBINARY_VERSION "3.2.14"
+#define PHP_IGBINARY_VERSION "3.2.15dev"
 
 /* Macros */
 

--- a/tests/igbinary_enums_3.phpt
+++ b/tests/igbinary_enums_3.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test unserializing valid enums inferring value
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80100) { echo "skip enums requires php 8.1"; } ?>
+--FILE--
+<?php
+
+enum X: string {
+    case X = X;
+}
+$x = 'X';
+define('X', "dynamic$x");
+$value = urldecode('%00%00%00%02%17%01X%27%0E%00');
+var_dump(igbinary_unserialize($value));
+$ser = igbinary_serialize(X::X);
+echo urlencode($ser), "\n";
+var_dump(X::X->value);
+?>
+--EXPECT--
+enum(X::X)
+%00%00%00%02%17%01X%27%0E%00
+string(8) "dynamicX"

--- a/tests/igbinary_enums_3_php83.phpt
+++ b/tests/igbinary_enums_3_php83.phpt
@@ -1,13 +1,15 @@
 --TEST--
 Test unserializing valid enums inferring value
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 80100) { echo "skip enums requires php 8.1"; } ?>
+<?php if (PHP_VERSION_ID < 80300) { echo "skip non-compile time constant in enums requires php 8.3"; } ?>
 --FILE--
 <?php
+
 enum X: string {
-    const Y = 'a';
-    case X = self::Y . 'b';
+    case X = X;
 }
+$x = 'X';
+define('X', "dynamic$x");
 $value = urldecode('%00%00%00%02%17%01X%27%0E%00');
 var_dump(igbinary_unserialize($value));
 $ser = igbinary_serialize(X::X);
@@ -17,4 +19,4 @@ var_dump(X::X->value);
 --EXPECT--
 enum(X::X)
 %00%00%00%02%17%01X%27%0E%00
-string(2) "ab"
+string(8) "dynamicX"


### PR DESCRIPTION
with `opcache.protect_memory=1`

Fixes #380

`igbinary_serialize()` now modifies the temporary copy used by the php process instead of the shared immutable copy in memcached, the same way as php `serialize()`