### PR TITLE
fix tests for 8.4

### DIFF
--- a/tests/__serialize_020.phpt
+++ b/tests/__serialize_020.phpt
@@ -23,7 +23,7 @@ class MessageEvents
         $this->transports[$event->getTransport()] = true;
     }
 
-    public function getEvents(string $name = null): array
+    public function getEvents(?string $name = null): array
     {
         return $this->events;
     }
@@ -229,7 +229,7 @@ final class Headers
         return array_shift($values);
     }
 
-    public function all(string $name = null): iterable
+    public function all(?string $name = null): iterable
     {
         if (null === $name) {
             foreach ($this->headers as $name => $collection) {
@@ -305,7 +305,7 @@ class RawMessage
 class Message extends RawMessage
 {
 
-    public function __construct(Headers $headers = null, AbstractPart $body = null)
+    public function __construct(?Headers $headers = null, ?AbstractPart $body = null)
     {
         $this->headers = $headers ? clone $headers : new Headers();
         $this->body = $body;

--- a/tests/igbinary_015.phpt
+++ b/tests/igbinary_015.phpt
@@ -50,7 +50,7 @@ function gc($time) {
 
 ini_set('session.serialize_handler', 'igbinary');
 
-session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
+@session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
 
 session_start();
 

--- a/tests/igbinary_015b.phpt
+++ b/tests/igbinary_015b.phpt
@@ -50,7 +50,7 @@ function gc($time) {
 	return true;
 }
 
-session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
+@session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
 
 session_start();
 

--- a/tests/igbinary_015c.phpt
+++ b/tests/igbinary_015c.phpt
@@ -51,7 +51,7 @@ function gc($time) {
 
 ini_set('session.serialize_handler', 'igbinary');
 
-session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
+@session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
 session_id('abcdef10231512dfaz_12311');
 
 session_start();

--- a/tests/igbinary_027.phpt
+++ b/tests/igbinary_027.phpt
@@ -59,7 +59,7 @@ class Bar {
 
 ini_set('session.serialize_handler', 'igbinary');
 
-session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
+@session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
 
 
 $db_object = new Foo();

--- a/tests/igbinary_028.phpt
+++ b/tests/igbinary_028.phpt
@@ -96,7 +96,7 @@ function gc($time) {
 
 ini_set('session.serialize_handler', 'igbinary');
 
-session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
+@session_set_save_handler('open', 'close', 'read', 'write', 'destroy', 'gc');
 
 session_start();
 

--- a/tests/igbinary_047.phpt
+++ b/tests/igbinary_047.phpt
@@ -64,7 +64,7 @@ class Bar {
 ini_set('session.serialize_handler', 'igbinary');
 
 $handler = new S();
-session_set_save_handler($handler, true);
+@session_set_save_handler($handler, true);
 
 $db_object = new Foo();
 $session_object = new Bar();


### PR DESCRIPTION
Fixes:

- Deprecated: Calling session_set_save_handler() with more than 2 arguments is deprecated ...
- Implicitly marking parameter xxx as nullable is deprecated, the explicit nullable type must be used instead...