### PR TITLE
E_STRICT is deprecated

### DIFF
--- a/tests/igbinary_009b_php8.phpt
+++ b/tests/igbinary_009b_php8.phpt
@@ -12,7 +12,7 @@ if (PHP_MAJOR_VERSION < 8) {
 pcre.jit=0
 --FILE--
 <?php
-error_reporting(E_ALL|E_STRICT);
+error_reporting(E_ALL);
 // Verify that $type[0] is the same zval as $type[0][0][0], but different from $type[0]
 function test_cyclic2($type, $variable) {
 	$serialized = igbinary_serialize($variable);


### PR DESCRIPTION
This causes the test to fail under PHP 8.4 and it isn't necessary for the test anyway