### PR TITLE
[Draft] Added PHP 8.5 to CI

### DIFF
--- a/.github/workflows/build_dlls.yml
+++ b/.github/workflows/build_dlls.yml
@@ -20,9 +20,9 @@ jobs:
           version:
           # 7.2 and 7.3 currently fail due to https://github.com/php/setup-php-sdk/issues/10
           # Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
-          - { os: windows-2022, php: "7.2" }
-          - { os: windows-2022, php: "7.3" }
-          - { os: windows-2022, php: "7.4" }
+          # - { os: windows-2019, php: "7.2" }
+          # - { os: windows-2019, php: "7.3" }
+          # - { os: windows-2019, php: "7.4" }
           - { os: windows-2022, php: "8.0" }
           - { os: windows-2022, php: "8.1" }
           - { os: windows-2022, php: "8.2" }

--- a/.github/workflows/build_dlls.yml
+++ b/.github/workflows/build_dlls.yml
@@ -27,6 +27,7 @@ jobs:
           - { os: windows-2022, php: "8.2" }
           - { os: windows-2022, php: "8.3" }
           - { os: windows-2022, php: "8.4" }
+          - { os: windows-2022, php: "8.5" }
           arch: [x64]
           ts: [nts, ts]
     # https://github.com/php/setup-php-sdk?tab=readme-ov-file#inputs
@@ -36,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@v0.9
+        uses: php/setup-php-sdk@v0.11
         with:
           version: ${{matrix.version.php}}
           arch: ${{matrix.arch}}

--- a/.github/workflows/build_dlls.yml
+++ b/.github/workflows/build_dlls.yml
@@ -19,9 +19,10 @@ jobs:
       matrix:
           version:
           # 7.2 and 7.3 currently fail due to https://github.com/php/setup-php-sdk/issues/10
-          - { os: windows-2019, php: "7.2" }
-          - { os: windows-2019, php: "7.3" }
-          - { os: windows-2019, php: "7.4" }
+          # Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
+          - { os: windows-2022, php: "7.2" }
+          - { os: windows-2022, php: "7.3" }
+          - { os: windows-2022, php: "7.4" }
           - { os: windows-2022, php: "8.0" }
           - { os: windows-2022, php: "8.1" }
           - { os: windows-2022, php: "8.2" }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,9 +86,10 @@ jobs:
       matrix:
           version:
           # 7.2 and 7.3 currently fail due to https://github.com/php/setup-php-sdk/issues/10
-          # - { os: windows-2019, php: "7.2" }
-          # - { os: windows-2019, php: "7.3" }
-          - { os: windows-2019, php: "7.4" }
+          # Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
+          - { os: windows-2022, php: "7.2" }
+          - { os: windows-2022, php: "7.3" }
+          - { os: windows-2022, php: "7.4" }
           - { os: windows-2022, php: "8.0" }
           - { os: windows-2022, php: "8.1" }
           - { os: windows-2022, php: "8.2" }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Build and test in docker
         run: bash ci/test_dockerized.sh ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}
 
+      - name: Setup apt for old PHP versions
+        if: matrix.PHP_VERSION == '7.0' || matrix.PHP_VERSION == '7.1' || matrix.PHP_VERSION == '7.2'
+        run: |
+          # Change the package mirrors of old Debian versions to archive.debian.org
+          sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
+          sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
+          # Disable InRelease check (not available on archive mirrors)
+          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+          apt-get update
       # We reuse the php base image because
       # 1. It has any necessary dependencies installed for php 7.0-8.2
       # 2. It is already downloaded
@@ -87,9 +96,9 @@ jobs:
           version:
           # 7.2 and 7.3 currently fail due to https://github.com/php/setup-php-sdk/issues/10
           # Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
-          - { os: windows-2022, php: "7.2" }
-          - { os: windows-2022, php: "7.3" }
-          - { os: windows-2022, php: "7.4" }
+          # - { os: windows-2019, php: "7.2" }
+          # - { os: windows-2019, php: "7.3" }
+          # - { os: windows-2019, php: "7.4" }
           - { os: windows-2022, php: "8.0" }
           - { os: windows-2022, php: "8.1" }
           - { os: windows-2022, php: "8.2" }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,16 +44,18 @@ jobs:
            PHP_VERSION_FULL: 8.0.30
            DOCKER_ARCHITECTURE: i386
          - PHP_VERSION: '8.1'
-           PHP_VERSION_FULL: 8.1.29
+           PHP_VERSION_FULL: 8.1.33
          - PHP_VERSION: '8.2'
-           PHP_VERSION_FULL: 8.2.22
+           PHP_VERSION_FULL: 8.2.29
          - PHP_VERSION: '8.2'
-           PHP_VERSION_FULL: 8.2.22
+           PHP_VERSION_FULL: 8.2.29
            DOCKER_ARCHITECTURE: i386
-         - PHP_VERSION: '8.3.10'
-           PHP_VERSION_FULL: 8.3.10
-         - PHP_VERSION: '8.4.0alpha4'
-           PHP_VERSION_FULL: 8.4.0alpha4
+         - PHP_VERSION: '8.3.26'
+           PHP_VERSION_FULL: 8.3.26
+         - PHP_VERSION: '8.4.13'
+           PHP_VERSION_FULL: 8.4.13
+         - PHP_VERSION: '8.5.0RC1'
+           PHP_VERSION_FULL: 8.5.0RC1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -92,6 +94,7 @@ jobs:
           - { os: windows-2022, php: "8.2" }
           - { os: windows-2022, php: "8.3" }
           - { os: windows-2022, php: "8.4" }
+          - { os: windows-2022, php: "8.5" }
           arch: [x64]
           ts: [nts, ts]
     # https://github.com/php/setup-php-sdk?tab=readme-ov-file#inputs
@@ -101,7 +104,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@v0.9
+        uses: php/setup-php-sdk@v0.11
         with:
           version: ${{matrix.version.php}}
           arch: ${{matrix.arch}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
           sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
           # Disable InRelease check (not available on archive mirrors)
-          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+          sudo echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
           apt-get update
       # We reuse the php base image because
       # 1. It has any necessary dependencies installed for php 7.0-8.2
@@ -85,7 +85,7 @@ jobs:
       # because php-src has inline assembly that causes false positives in valgrind when that option isn't used.
       # The OS release in the PHP 7.0 image is too old to install valgrind without workarounds: https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found
       - name: Build and test in docker again with valgrind
-        run: if [[ ${{ matrix.PHP_VERSION }} != '7.0' ]]; then bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}; fi
+        run: bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}
       # NOTE: tests report false positives for zend_string_equals in php 7.3+
       # due to the use of inline assembly in php-src. (not related to igbinary)
   windows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches:
-      - "master"
-      - "php-8-5"
+    branches: [ "master", "php-8.5" ]
   pull_request:
     branches: [ master ]
 
@@ -74,6 +72,8 @@ jobs:
           # Change the package mirrors of old Debian versions to archive.debian.org
           sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
           sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
+          # Disable InRelease check (not available on archive mirrors)
+          echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid-until
           apt-get update
       # We reuse the php base image because
       # 1. It has any necessary dependencies installed for php 7.0-8.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - php-8-5
   pull_request:
     branches: [ master ]
 
@@ -70,8 +72,8 @@ jobs:
         if: matrix.PHP_VERSION == '7.0' || matrix.PHP_VERSION == '7.1' || matrix.PHP_VERSION == '7.2'
         run: |
           # Change the package mirrors of old Debian versions to archive.debian.org
-          sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
-          sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
+          sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
+          sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
           # Disable InRelease check (not available on archive mirrors)
           echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
           apt-get update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ "master", "php-8.5" ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -72,7 +72,7 @@ jobs:
       #
       # We need to install valgrind then rebuild php from source with the configure option '--with-valgrind' to avoid valgrind false positives
       # because php-src has inline assembly that causes false positives in valgrind when that option isn't used.
-      # The OS release in the PHP 7.0 image is too old to install valgrind without workarounds: https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found
+      # The OS release in the PHP 7.0, 7.1, 7.2 image is too old to install valgrind without workarounds: https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found
       - name: Build and test in docker again with valgrind
         run: if [[ ${{ matrix.PHP_VERSION }} != '7.0' && ${{ matrix.PHP_VERSION }} != '7.1' && ${{ matrix.PHP_VERSION }} != '7.2' ]]; then bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}; fi
       # NOTE: tests report false positives for zend_string_equals in php 7.3+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [ "master", "php-8.5" ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches:
-      - master
-      - php-8-5
+      - "master"
+      - "php-8-5"
   pull_request:
     branches: [ master ]
 
@@ -74,8 +74,6 @@ jobs:
           # Change the package mirrors of old Debian versions to archive.debian.org
           sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
           sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
-          # Disable InRelease check (not available on archive mirrors)
-          sudo echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
           apt-get update
       # We reuse the php base image because
       # 1. It has any necessary dependencies installed for php 7.0-8.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,15 +66,6 @@ jobs:
       - name: Build and test in docker
         run: bash ci/test_dockerized.sh ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}
 
-      - name: Setup apt for old PHP versions
-        if: matrix.PHP_VERSION == '7.0' || matrix.PHP_VERSION == '7.1' || matrix.PHP_VERSION == '7.2'
-        run: |
-          # Change the package mirrors of old Debian versions to archive.debian.org
-          sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
-          sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
-          # Disable InRelease check (not available on archive mirrors)
-          echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid-until
-          sudo apt-get update
       # We reuse the php base image because
       # 1. It has any necessary dependencies installed for php 7.0-8.2
       # 2. It is already downloaded
@@ -83,7 +74,7 @@ jobs:
       # because php-src has inline assembly that causes false positives in valgrind when that option isn't used.
       # The OS release in the PHP 7.0 image is too old to install valgrind without workarounds: https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found
       - name: Build and test in docker again with valgrind
-        run: bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}
+        run: if [[ ${{ matrix.PHP_VERSION }} != '7.0' && ${{ matrix.PHP_VERSION }} != '7.1' && ${{ matrix.PHP_VERSION }} != '7.2' ]]; then bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}; fi
       # NOTE: tests report false positives for zend_string_equals in php 7.3+
       # due to the use of inline assembly in php-src. (not related to igbinary)
   windows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           sudo sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
           # Disable InRelease check (not available on archive mirrors)
           echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid-until
-          apt-get update
+          sudo apt-get update
       # We reuse the php base image because
       # 1. It has any necessary dependencies installed for php 7.0-8.2
       # 2. It is already downloaded

--- a/tests/__serialize_004.phpt
+++ b/tests/__serialize_004.phpt
@@ -1,7 +1,11 @@
 --TEST--
 __serialize() mechanism (004): Delayed __unserialize() calls
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70400) { echo "skip __serialize/__unserialize not supported in php < 7.4 for compatibility with serialize()\n"; } ?>
+<?php if (PHP_VERSION_ID < 70400) { echo "skip __serialize/__unserialize not supported in php < 7.4 for compatibility with serialize()\n"; }
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 

--- a/tests/__serialize_015.phpt
+++ b/tests/__serialize_015.phpt
@@ -3,6 +3,9 @@ __serialize() mechanism (015): Uninitialized properties from __sleep should thro
 --SKIPIF--
 <?php
 if (PHP_VERSION_ID < 70400) { echo "skip __serialize/__unserialize not supported in php < 7.4 for compatibility with igbinary_serialize()"; }
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
 ?>
 --FILE--
 <?php

--- a/tests/igbinary_016.phpt
+++ b/tests/igbinary_016.phpt
@@ -1,6 +1,11 @@
 --TEST--
 Object test, __sleep
 --SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_017.phpt
+++ b/tests/igbinary_017.phpt
@@ -1,6 +1,11 @@
 --TEST--
 Object test, __wakeup
 --SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_018.phpt
+++ b/tests/igbinary_018.phpt
@@ -1,6 +1,11 @@
 --TEST--
 Object test, __sleep error cases
 --SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_025.phpt
+++ b/tests/igbinary_025.phpt
@@ -1,6 +1,11 @@
 --TEST--
 Object test, array of objects with __sleep
 --SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_025b.phpt
+++ b/tests/igbinary_025b.phpt
@@ -1,6 +1,11 @@
 --TEST--
 Object test, array of small objects with __sleep
 --SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_032.phpt
+++ b/tests/igbinary_032.phpt
@@ -2,6 +2,9 @@
 Object test, __sleep and __wakeup exceptions
 --SKIPIF--
 <?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
 if(!extension_loaded('igbinary')) {
 	echo "skip no igbinary";
 }

--- a/tests/igbinary_051.phpt
+++ b/tests/igbinary_051.phpt
@@ -1,6 +1,11 @@
 --TEST--
 Object test, __wakeup (With multiple references)
 --SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 if(!extension_loaded('igbinary')) {

--- a/tests/igbinary_053.phpt
+++ b/tests/igbinary_053.phpt
@@ -1,5 +1,11 @@
 --TEST--
 __wakeup can modify properties without affecting other objects
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 

--- a/tests/igbinary_054.phpt
+++ b/tests/igbinary_054.phpt
@@ -1,5 +1,11 @@
 --TEST--
 __wakeup can add dynamic properties without affecting other objects
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 

--- a/tests/igbinary_055.phpt
+++ b/tests/igbinary_055.phpt
@@ -1,5 +1,11 @@
 --TEST--
 __wakeup can replace a copy of the object referring to the root node.
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 

--- a/tests/igbinary_058.phpt
+++ b/tests/igbinary_058.phpt
@@ -2,6 +2,12 @@
 Should not call __destruct if __wakeup throws an exception
 --INI--
 igbinary.compact_strings = On
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 class Thrower {

--- a/tests/igbinary_058b.phpt
+++ b/tests/igbinary_058b.phpt
@@ -2,6 +2,12 @@
 Should not call __destruct if __wakeup throws an exception (in arrays)
 --INI--
 igbinary.compact_strings = On
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 class Thrower {

--- a/tests/igbinary_061.phpt
+++ b/tests/igbinary_061.phpt
@@ -5,6 +5,9 @@ date.timezone=UTC
 session.serialize_handler=igbinary
 --SKIPIF--
 <?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
 if (!extension_loaded('session')) {
 	exit('skip session extension not loaded');
 }

--- a/tests/igbinary_065.phpt
+++ b/tests/igbinary_065.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Don't emit zval has unknown type 0 (IS_UNDEF)
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 function var_export_normalized($value) { echo ltrim(var_export($value, true), "\\"); }

--- a/tests/igbinary_078.phpt
+++ b/tests/igbinary_078.phpt
@@ -1,5 +1,11 @@
 --TEST--
 igbinary and large arrays
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 class BadSleep {

--- a/tests/igbinary_084.phpt
+++ b/tests/igbinary_084.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Properly free duplicate properties when unserializing invalid data
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 class Test {

--- a/tests/igbinary_084b.phpt
+++ b/tests/igbinary_084b.phpt
@@ -3,6 +3,9 @@ Properly free duplicate undeclared properties when unserializing invalid data
 --SKIPIF--
 <?php
 if (PHP_VERSION_ID >= 90000) { echo "skip requires php < 9.0 when testing that the deprecation has no impact on igbinary functionality\n"; }
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
 ?>
 --FILE--
 <?php

--- a/tests/igbinary_087.phpt
+++ b/tests/igbinary_087.phpt
@@ -1,7 +1,11 @@
 --TEST--
 Test serializing many values in __sleep
 --SKIPIF--
-<?php if (!extension_loaded("igbinary")) print "skip"; ?>
+<?php if (!extension_loaded("igbinary")) print "skip";
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 #[AllowDynamicProperties]

--- a/tests/igbinary_088.phpt
+++ b/tests/igbinary_088.phpt
@@ -1,7 +1,11 @@
 --TEST--
 Test serializing wrong values in __sleep
 --SKIPIF--
-<?php if (!extension_loaded("igbinary")) print "skip"; ?>
+<?php if (!extension_loaded("igbinary")) print "skip";
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 #[AllowDynamicProperties]

--- a/tests/sleep_mangled_name_clash.phpt
+++ b/tests/sleep_mangled_name_clash.phpt
@@ -1,5 +1,11 @@
 --TEST--
 __sleep() returns properties clashing only after mangling
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80500) {
+    echo "skip: __sleep() and __wakeup() are deprecated in PHP 8.5+ (see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods)";
+}
+?>
 --FILE--
 <?php
 class Test {


### PR DESCRIPTION
### Work in progress



TEST 151/151 [1/4 concurrent test workers running]
                                                   

TIME END 2025-10-06 20:42:24


TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   36


Number of tests :  151               135
Tests skipped   :   16 ( 10.6%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :   22 ( 14.6%) ( 16.3%)
Tests passed    :  113 ( 74.8%) ( 83.7%)

Time taken      :    2 seconds



FAILED TEST SUMMARY
---------------------------------------------------------------------

- Don't emit zval has unknown type 0 (IS_UNDEF) [tests/igbinary_065.phpt]
- __serialize() mechanism (004): Delayed __unserialize() calls [tests/__serialize_004.phpt]
- Object test, __sleep [tests/igbinary_016.phpt]
- Object test, __wakeup [tests/igbinary_017.phpt]
- Object test, __sleep error cases [tests/igbinary_018.phpt]
- igbinary and large arrays [tests/igbinary_078.phpt]
- Object test, __wakeup (With multiple references) [tests/igbinary_051.phpt]
- __wakeup can modify properties without affecting other objects [tests/igbinary_053.phpt]
- Object test, array of objects with __sleep [tests/igbinary_025.phpt]
- Object test, array of small objects with __sleep [tests/igbinary_025b.phpt]
- __wakeup can add dynamic properties without affecting other objects [tests/igbinary_054.phpt]
- __wakeup can replace a copy of the object referring to the root node. [tests/igbinary_055.phpt]
- __serialize() mechanism (015): Uninitialized properties from __sleep should throw when serializing [tests/__serialize_015.phpt]
- Properly free duplicate properties when unserializing invalid data [tests/igbinary_084.phpt]
- Should not call __destruct if __wakeup throws an exception [tests/igbinary_058.phpt]
- Should not call __destruct if __wakeup throws an exception (in arrays) [tests/igbinary_058b.phpt]
- Properly free duplicate undeclared properties when unserializing invalid data [tests/igbinary_084b.phpt]
- igbinary session decoder should call __wakeup [tests/igbinary_061.phpt]
- Test serializing many values in __sleep [tests/igbinary_087.phpt]
- Test serializing wrong values in __sleep [tests/igbinary_088.phpt]
- Object test, __sleep and __wakeup exceptions [tests/igbinary_032.phpt]
- __sleep() returns properties clashing only after mangling [tests/sleep_mangled_name_clash.phpt]
