### PR TITLE
Fix Windows CI and build pipelines for PHP >= 8.1

### DIFF
--- a/.github/workflows/build_dlls.yml
+++ b/.github/workflows/build_dlls.yml
@@ -46,7 +46,7 @@ jobs:
                 $process = Start-Process -FilePath cmd.exe -ArgumentList $args -Wait -PassThru -WindowStyle Hidden
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@v0.11
+        uses: php/setup-php-sdk@v0.12
         with:
           version: ${{matrix.version.php}}
           arch: ${{matrix.arch}}

--- a/.github/workflows/build_dlls.yml
+++ b/.github/workflows/build_dlls.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{matrix.version.os}}
     steps:
       - name: Checkout igbinary
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Install VC15 component
         if: ${{ matrix.version.php == '7.4' || matrix.version.php == '7.3' || matrix.version.php == '7.2' }}
         shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
                 $process = Start-Process -FilePath cmd.exe -ArgumentList $args -Wait -PassThru -WindowStyle Hidden
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@v0.11
+        uses: php/setup-php-sdk@v0.12
         with:
           version: ${{matrix.version.php}}
           arch: ${{matrix.arch}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,27 +35,27 @@ jobs:
          - PHP_VERSION: '7.2'
            PHP_VERSION_FULL: 7.2.34
          - PHP_VERSION: '7.3'
-           PHP_VERSION_FULL: 7.3.32
+           PHP_VERSION_FULL: 7.3.33
          - PHP_VERSION: '7.4'
-           PHP_VERSION_FULL: 7.4.30
+           PHP_VERSION_FULL: 7.4.33
          - PHP_VERSION: '8.0'
            PHP_VERSION_FULL: 8.0.30
          - PHP_VERSION: '8.0'
            PHP_VERSION_FULL: 8.0.30
            DOCKER_ARCHITECTURE: i386
          - PHP_VERSION: '8.1'
-           PHP_VERSION_FULL: 8.1.33
+           PHP_VERSION_FULL: 8.1.34
          - PHP_VERSION: '8.2'
-           PHP_VERSION_FULL: 8.2.29
+           PHP_VERSION_FULL: 8.2.30
          - PHP_VERSION: '8.2'
-           PHP_VERSION_FULL: 8.2.29
+           PHP_VERSION_FULL: 8.2.30
            DOCKER_ARCHITECTURE: i386
          - PHP_VERSION: '8.3'
-           PHP_VERSION_FULL: 8.3.26
+           PHP_VERSION_FULL: 8.3.30
          - PHP_VERSION: '8.4'
-           PHP_VERSION_FULL: 8.4.13
+           PHP_VERSION_FULL: 8.4.20
          - PHP_VERSION: '8.5'
-           PHP_VERSION_FULL: 8.5.0RC1
+           PHP_VERSION_FULL: 8.5.5
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Runs a single command using the runners shell
       - name: Build and test in docker
@@ -93,7 +93,7 @@ jobs:
     runs-on: ${{matrix.version.os}}
     steps:
       - name: Checkout igbinary
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Install VC15 component
         if: ${{ matrix.version.php == '7.4' || matrix.version.php == '7.3' || matrix.version.php == '7.2' }}
         shell: pwsh

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -41,10 +41,10 @@ else
 	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 
 	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-	PHP_TAR_URL=https://secure.php.net/distributions/$PHP_TAR_FILE
+	PHP_TAR_URL=https://www.php.net/distributions/$PHP_TAR_FILE
 fi
 if [ ! -f $PHP_TAR_FILE ]; then
-	curl --location --verbose $PHP_TAR_URL -o $PHP_TAR_FILE
+	curl --location --verbose --http1.1 $PHP_TAR_URL -o $PHP_TAR_FILE
 fi
 
 tar xjf $PHP_TAR_FILE


### PR DESCRIPTION
Running Windows pipelines for PHP >= 8.1 failed with setup-php-sdk@v0.11 due to TLS issues. Using setup-php-sdk@v0.12 resolves this by explicitly enabling TLS 1.2 and TLS 1.3. Additionally, download failures were fixed by limiting curl to use HTTP 1.1 and GitHub actions/checkout are updated to v6 due to the Node.js 20 deprecation.