### PR TITLE
Cap unserialize recursion depth via unserialize_max_depth ini

### DIFF
--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -24,6 +24,7 @@
 #include "ext/standard/info.h"
 #include "ext/standard/php_var.h"
 #include "ext/standard/basic_functions.h" /* BG(unserialize_max_depth) */
+#include <inttypes.h> /* PRId32/PRId64 used by ZEND_LONG_FMT */
 
 #if PHP_VERSION_ID >= 80100
 #include "Zend/zend_enum.h"

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -23,7 +23,6 @@
 #include "Zend/zend_compile.h" /* ZEND_ACC_NOT_SERIALIZABLE */
 #include "ext/standard/info.h"
 #include "ext/standard/php_var.h"
-#include "ext/standard/basic_functions.h" /* BG(unserialize_max_depth) */
 #include <inttypes.h> /* PRId32/PRId64 used by ZEND_LONG_FMT */
 
 #if PHP_VERSION_ID >= 80100
@@ -2055,7 +2054,7 @@ inline static int igbinary_unserialize_data_init(struct igbinary_unserialize_dat
 	/* so callers that ignore the return value still see defined values. */
 	igsd->cur_depth = 0;
 #if PHP_VERSION_ID >= 70400
-	igsd->max_depth = BG(unserialize_max_depth);
+	igsd->max_depth = zend_ini_long((char *)"unserialize_max_depth", sizeof("unserialize_max_depth") - 1, 0);
 #else
 	/* unserialize_max_depth ini was added in PHP 7.4. */
 	/* Use the same default cap to keep the recursion guard active on older builds. */

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -333,7 +333,7 @@ zend_always_inline static int igbinary_unserialize_array(struct igbinary_unseria
 zend_always_inline static int igbinary_unserialize_object(struct igbinary_unserialize_data *igsd, enum igbinary_type t, zval *const z, int flags);
 static int igbinary_unserialize_object_ser(struct igbinary_unserialize_data *igsd, enum igbinary_type t, zval *const z, zend_class_entry *ce);
 
-static int igbinary_unserialize_zval(struct igbinary_unserialize_data *igsd, zval *const z, int flags);
+zend_always_inline static int igbinary_unserialize_zval(struct igbinary_unserialize_data *igsd, zval *const z, int flags);
 static int igbinary_unserialize_zval_inner(struct igbinary_unserialize_data *igsd, zval *const z, int flags);
 /* }}} */
 /* {{{ arginfo */
@@ -3444,15 +3444,13 @@ zend_always_inline static int igbinary_unserialize_ref(struct igbinary_unseriali
  *  Recursion-depth wrapper -- enforces the unserialize_max_depth ini setting before
  *  delegating to igbinary_unserialize_zval_inner, mirroring the protection PHP core's
  *  unserialize() applies via php_var_unserialize. */
-static int igbinary_unserialize_zval(struct igbinary_unserialize_data *igsd, zval *const z, int flags) {
+zend_always_inline static int igbinary_unserialize_zval(struct igbinary_unserialize_data *igsd, zval *const z, int flags) {
 	int ret;
-	if (igsd->max_depth > 0 && igsd->cur_depth >= igsd->max_depth) {
-		/* Cast to (long) and use %ld so this builds on Windows without */
-		/* needing <inttypes.h>, which igbinary intentionally skips there. */
+	if (UNEXPECTED(igsd->cur_depth >= igsd->max_depth && igsd->max_depth > 0)) {
 		php_error_docref(NULL, E_WARNING,
-			"Maximum depth of %ld exceeded. "
+			"Maximum depth of " ZEND_LONG_FMT " exceeded. "
 			"The depth limit can be changed using the unserialize_max_depth ini setting",
-			(long)igsd->max_depth);
+			igsd->max_depth);
 		return 1;
 	}
 	igsd->cur_depth++;

--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -23,6 +23,7 @@
 #include "Zend/zend_compile.h" /* ZEND_ACC_NOT_SERIALIZABLE */
 #include "ext/standard/info.h"
 #include "ext/standard/php_var.h"
+#include "ext/standard/basic_functions.h" /* BG(unserialize_max_depth) */
 
 #if PHP_VERSION_ID >= 80100
 #include "Zend/zend_enum.h"
@@ -273,6 +274,8 @@ struct igbinary_unserialize_data {
 #if PHP_VERSION_ID >= 70400
 	HashTable *ref_props; /**< objects&data for calls to __unserialize/__wakeup */
 #endif
+	zend_long cur_depth;            /**< current recursion depth in igbinary_unserialize_zval */
+	zend_long max_depth;            /**< snapshot of unserialize_max_depth ini at entry */
 };
 
 #define IGB_REF_VAL_2(igsd, n)	((igsd)->references[(n)])
@@ -331,6 +334,7 @@ zend_always_inline static int igbinary_unserialize_object(struct igbinary_unseri
 static int igbinary_unserialize_object_ser(struct igbinary_unserialize_data *igsd, enum igbinary_type t, zval *const z, zend_class_entry *ce);
 
 static int igbinary_unserialize_zval(struct igbinary_unserialize_data *igsd, zval *const z, int flags);
+static int igbinary_unserialize_zval_inner(struct igbinary_unserialize_data *igsd, zval *const z, int flags);
 /* }}} */
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_igbinary_serialize, 0, 0, 1)
@@ -2044,8 +2048,19 @@ static int igbinary_serialize_zval(struct igbinary_serialize_data *igsd, zval *z
 /* {{{ igbinary_unserialize_data_init */
 /** Inits igbinary_unserialize_data. */
 inline static int igbinary_unserialize_data_init(struct igbinary_unserialize_data *igsd) {
-	struct igbinary_value_ref *references = emalloc(sizeof(igsd->references[0]) * 4);
+	struct igbinary_value_ref *references;
 	zend_string **strings;
+	/* Initialize the recursion guard fields before any path that can fail, */
+	/* so callers that ignore the return value still see defined values. */
+	igsd->cur_depth = 0;
+#if PHP_VERSION_ID >= 70400
+	igsd->max_depth = BG(unserialize_max_depth);
+#else
+	/* unserialize_max_depth ini was added in PHP 7.4. */
+	/* Use the same default cap to keep the recursion guard active on older builds. */
+	igsd->max_depth = 4096;
+#endif
+	references = emalloc(sizeof(igsd->references[0]) * 4);
 	if (UNEXPECTED(references == NULL)) {
 		return 1;
 	}
@@ -3425,8 +3440,29 @@ zend_always_inline static int igbinary_unserialize_ref(struct igbinary_unseriali
 }
 /* }}} */
 /* {{{ igbinary_unserialize_zval */
-/** Unserialize a zval of any serializable type (zval is PHP's internal representation of a value). */
+/** Unserialize a zval of any serializable type (zval is PHP's internal representation of a value).
+ *  Recursion-depth wrapper -- enforces the unserialize_max_depth ini setting before
+ *  delegating to igbinary_unserialize_zval_inner, mirroring the protection PHP core's
+ *  unserialize() applies via php_var_unserialize. */
 static int igbinary_unserialize_zval(struct igbinary_unserialize_data *igsd, zval *const z, int flags) {
+	int ret;
+	if (igsd->max_depth > 0 && igsd->cur_depth >= igsd->max_depth) {
+		/* Cast to (long) and use %ld so this builds on Windows without */
+		/* needing <inttypes.h>, which igbinary intentionally skips there. */
+		php_error_docref(NULL, E_WARNING,
+			"Maximum depth of %ld exceeded. "
+			"The depth limit can be changed using the unserialize_max_depth ini setting",
+			(long)igsd->max_depth);
+		return 1;
+	}
+	igsd->cur_depth++;
+	ret = igbinary_unserialize_zval_inner(igsd, z, flags);
+	igsd->cur_depth--;
+	return ret;
+}
+/* }}} */
+/* {{{ igbinary_unserialize_zval_inner */
+static int igbinary_unserialize_zval_inner(struct igbinary_unserialize_data *igsd, zval *const z, int flags) {
 	enum igbinary_type t;
 
 	zend_long tmp_long;

--- a/tests/igbinary_unserialize_max_depth.phpt
+++ b/tests/igbinary_unserialize_max_depth.phpt
@@ -24,14 +24,10 @@ var_dump(igbinary_unserialize($ok) !== null);
 ini_set('unserialize_max_depth', '0');
 var_dump(igbinary_unserialize($ok) !== null);
 
-// Synthetic 50000-level payload: depth-bomb is rejected at the small cap
+// Synthetic deeply-nested payload: depth-bomb is rejected at the small cap
 // without ever recursing past 100 frames, proving the crash protection.
 ini_set('unserialize_max_depth', '100');
-$bomb = "\x00\x00\x00\x02";
-for ($i = 0; $i < 50000; $i++) {
-    $bomb .= "\x14\x01\x11\x01x";
-}
-$bomb .= "\x00";
+$bomb = "\x00\x00\x00\x02" . str_repeat("\x14\x01\x11\x01x", 5000) . "\x00";
 var_dump(igbinary_unserialize($bomb));
 ?>
 --EXPECTF--

--- a/tests/igbinary_unserialize_max_depth.phpt
+++ b/tests/igbinary_unserialize_max_depth.phpt
@@ -1,0 +1,44 @@
+--TEST--
+igbinary_unserialize honors unserialize_max_depth ini setting
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70400) { echo "skip unserialize_max_depth ini was added in PHP 7.4"; } ?>
+--FILE--
+<?php
+// Build a 200-deep nested array. All cap exercises stay shallow on purpose
+// so the test does not stress the C stack under valgrind in CI.
+$deep = null;
+for ($i = 0; $i < 200; $i++) {
+    $deep = ['x' => $deep];
+}
+$ok = igbinary_serialize($deep);
+
+// Cap below payload depth: bail with warning, return null.
+ini_set('unserialize_max_depth', '100');
+var_dump(igbinary_unserialize($ok));
+
+// Cap above payload depth: round-trips successfully.
+ini_set('unserialize_max_depth', '500');
+var_dump(igbinary_unserialize($ok) !== null);
+
+// Cap = 0 disables the limit, matching PHP core unserialize() semantics.
+ini_set('unserialize_max_depth', '0');
+var_dump(igbinary_unserialize($ok) !== null);
+
+// Synthetic 50000-level payload: depth-bomb is rejected at the small cap
+// without ever recursing past 100 frames, proving the crash protection.
+ini_set('unserialize_max_depth', '100');
+$bomb = "\x00\x00\x00\x02";
+for ($i = 0; $i < 50000; $i++) {
+    $bomb .= "\x14\x01\x11\x01x";
+}
+$bomb .= "\x00";
+var_dump(igbinary_unserialize($bomb));
+?>
+--EXPECTF--
+Warning: igbinary_unserialize(): Maximum depth of 100 exceeded. The depth limit can be changed using the unserialize_max_depth ini setting in %s on line %d
+NULL
+bool(true)
+bool(true)
+
+Warning: igbinary_unserialize(): Maximum depth of 100 exceeded. The depth limit can be changed using the unserialize_max_depth ini setting in %s on line %d
+NULL


### PR DESCRIPTION
Cap recursion in `igbinary_unserialize_zval` at `BG(unserialize_max_depth)` (default 4096, 0 disables) on PHP 7.4+, hardcoded 4096 on 7.0-7.3. Without the cap, a deeply nested payload exhausts the C stack and segfaults the worker, reachable via `session.serialize_handler=igbinary` before userland code runs