### PR TITLE
Guard igbinary_serialize() against C stack overflow on deep nesting

### DIFF
--- a/src/php7/igbinary.c
+++ b/src/php7/igbinary.c
@@ -1980,9 +1980,28 @@ static ZEND_COLD int igbinary_warn_serialize_resource(zval *z) {
 	return EG(exception) != NULL;
 }
 /* }}} */
+/* {{{ igbinary_serialize_check_stack_limit */
+/** Mirrors php_serialize_check_stack_limit() in ext/standard/var.c: turns deep
+ *  recursion into a catchable Error instead of a C stack-overflow crash. No-op
+ *  on builds without the Zend stack-limit feature (PHP < 8.3). The error is
+ *  thrown directly (as PHP 8.3 core does) since zend_call_stack_size_error()
+ *  has no public declaration before 8.4. */
+static zend_always_inline bool igbinary_serialize_check_stack_limit(void) {
+#ifdef ZEND_CHECK_STACK_LIMIT
+	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+		zend_throw_error(NULL, "Maximum call stack size reached. Infinite recursion?");
+		return true;
+	}
+#endif
+	return false;
+}
+/* }}} */
 /* {{{ igbinary_serialize_zval */
 /** Serialize zval. */
 static int igbinary_serialize_zval(struct igbinary_serialize_data *igsd, zval *z) {
+	if (UNEXPECTED(igbinary_serialize_check_stack_limit())) {
+		return 1;
+	}
 	if (Z_ISREF_P(z)) {
 		if (Z_REFCOUNT_P(z) >= 2) {
 			RETURN_1_IF_NON_ZERO(igbinary_serialize8(igsd, (uint8_t)igbinary_type_ref))

--- a/tests/igbinary_serialize_deep_nesting.phpt
+++ b/tests/igbinary_serialize_deep_nesting.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Deeply nested input to igbinary_serialize() throws a catchable Error instead of crashing
+--SKIPIF--
+<?php
+if (!extension_loaded("igbinary")) die("skip");
+if (ini_get('zend.max_allowed_stack_size') === false) die("skip No stack limit support");
+if (getenv('SKIP_ASAN')) die("skip ASAN needs different stack limit setting due to more stack space usage");
+?>
+--INI--
+zend.max_allowed_stack_size=512K
+--FILE--
+<?php
+class Node
+{
+    public $next;
+}
+$firstNode = new Node();
+$node = $firstNode;
+for ($i = 0; $i < 30000; $i++) {
+    $newNode = new Node();
+    $node->next = $newNode;
+    $node = $newNode;
+}
+
+try {
+    igbinary_serialize($firstNode);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// Unlink iteratively so the engine does not recurse while destroying the chain.
+while ($next = $firstNode->next) {
+    $firstNode->next = $next->next;
+}
+
+?>
+--EXPECT--
+Maximum call stack size reached. Infinite recursion?


### PR DESCRIPTION
igbinary_serialize_zval() recurses once per nesting level with no depth or stack-limit check, so a deep enough array or object overflows the C stack and segfaults the process. Core's serialize() guards the same recursion via php_serialize_check_stack_limit() (added in 8.3) and throws a catchable Error; igbinary crashes where core recovers. This is the serialize-side counterpart to the unserialize cap in #414.

Reproducer (segfaults before this change):

    $a = "x";
    for ($i = 0; $i < 100000; $i++) $a = [$a];
    igbinary_serialize($a);

The fix checks zend_call_stack_overflowed(EG(stack_limit)) at the top of igbinary_serialize_zval() and raises via zend_call_stack_size_error(). No-op without ZEND_CHECK_STACK_LIMIT (PHP < 8.3), where core had no guard either. Test mirrors ext/standard/tests/serialize/gh15169.phpt.